### PR TITLE
feat(back): rotas entidades, testes unitarios, POST e DELETE das entidades

### DIFF
--- a/apps/back/prisma/migrations/20260621120000_membro_unique_perfil_entidade/migration.sql
+++ b/apps/back/prisma/migrations/20260621120000_membro_unique_perfil_entidade/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "Membro_idPerfil_idEntidade_key" ON "Membro"("idPerfil", "idEntidade");

--- a/apps/back/prisma/schema.prisma
+++ b/apps/back/prisma/schema.prisma
@@ -61,6 +61,8 @@ model Membro {
 
   gerenteProjetos     gerentesProjetos[]
   colaboradorProjetos colaboradoresProjetos[]
+
+  @@unique([idPerfil, idEntidade])
 }
 
 model Seguindo {

--- a/apps/back/src/entidade/entidade.controller.spec.ts
+++ b/apps/back/src/entidade/entidade.controller.spec.ts
@@ -1,20 +1,93 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ClassificacaoMembro } from '@prisma/client';
 import { EntidadeController } from './entidade.controller';
 import { EntidadeService } from './entidade.service';
 
 describe('EntidadeController', () => {
   let controller: EntidadeController;
+  const entidadeService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findMinhasEntidades: jest.fn(),
+    addMembro: jest.fn(),
+    removeMembro: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [EntidadeController],
-      providers: [EntidadeService],
+      providers: [
+        {
+          provide: EntidadeService,
+          useValue: entidadeService,
+        },
+      ],
     }).compile();
 
     controller = module.get<EntidadeController>(EntidadeController);
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should list entities for the authenticated user', () => {
+    const req: Parameters<EntidadeController['findMinhasEntidades']>[0] = {
+      user: { id: '7', email: 'user@aluno.unb.br' },
+    } as Parameters<EntidadeController['findMinhasEntidades']>[0];
+
+    entidadeService.findMinhasEntidades.mockReturnValue([
+      { id: 1, nome: 'Conecta UnB', vinculo: { classificacao: 'GESTOR' } },
+    ]);
+
+    expect(controller.findMinhasEntidades(req)).toEqual([
+      { id: 1, nome: 'Conecta UnB', vinculo: { classificacao: 'GESTOR' } },
+    ]);
+    expect(entidadeService.findMinhasEntidades).toHaveBeenCalledWith(7);
+  });
+
+  it('should add members using authenticated manager id', () => {
+    const dto = { idPerfil: 9, classificacao: ClassificacaoMembro.MEMBRO };
+    const req: Parameters<EntidadeController['addMembro']>[2] = {
+      user: { id: '7', email: 'gestor@aluno.unb.br' },
+    } as Parameters<EntidadeController['addMembro']>[2];
+
+    entidadeService.addMembro.mockReturnValue({
+      id: 11,
+      idPerfil: 9,
+      idEntidade: 1,
+      classificacao: 'MEMBRO',
+    });
+
+    expect(controller.addMembro('1', dto, req)).toEqual({
+      id: 11,
+      idPerfil: 9,
+      idEntidade: 1,
+      classificacao: 'MEMBRO',
+    });
+    expect(entidadeService.addMembro).toHaveBeenCalledWith(1, 7, dto);
+  });
+
+  it('should remove members using authenticated manager id', () => {
+    const req: Parameters<EntidadeController['removeMembro']>[2] = {
+      user: { id: '7', email: 'gestor@aluno.unb.br' },
+    } as Parameters<EntidadeController['removeMembro']>[2];
+
+    entidadeService.removeMembro.mockReturnValue({
+      idEntidade: 1,
+      idPerfil: 9,
+      removed: true,
+    });
+
+    expect(controller.removeMembro('1', '9', req)).toEqual({
+      idEntidade: 1,
+      idPerfil: 9,
+      removed: true,
+    });
+    expect(entidadeService.removeMembro).toHaveBeenCalledWith(1, 7, 9);
   });
 });

--- a/apps/back/src/entidade/entidade.controller.spec.ts
+++ b/apps/back/src/entidade/entidade.controller.spec.ts
@@ -31,20 +31,21 @@ describe('EntidadeController', () => {
     jest.clearAllMocks();
   });
 
+  const buildReq = () =>
+    ({ user: { id: '7', email: 'user@aluno.unb.br' } }) as Parameters<
+      EntidadeController['findMinhasEntidades']
+    >[0];
+
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
 
   it('should list entities for the authenticated user', () => {
-    const req: Parameters<EntidadeController['findMinhasEntidades']>[0] = {
-      user: { id: '7', email: 'user@aluno.unb.br' },
-    } as Parameters<EntidadeController['findMinhasEntidades']>[0];
-
     entidadeService.findMinhasEntidades.mockReturnValue([
       { id: 1, nome: 'Conecta UnB', vinculo: { classificacao: 'GESTOR' } },
     ]);
 
-    expect(controller.findMinhasEntidades(req)).toEqual([
+    expect(controller.findMinhasEntidades(buildReq())).toEqual([
       { id: 1, nome: 'Conecta UnB', vinculo: { classificacao: 'GESTOR' } },
     ]);
     expect(entidadeService.findMinhasEntidades).toHaveBeenCalledWith(7);
@@ -52,10 +53,6 @@ describe('EntidadeController', () => {
 
   it('should add members using authenticated manager id', () => {
     const dto = { idPerfil: 9, classificacao: ClassificacaoMembro.MEMBRO };
-    const req: Parameters<EntidadeController['addMembro']>[2] = {
-      user: { id: '7', email: 'gestor@aluno.unb.br' },
-    } as Parameters<EntidadeController['addMembro']>[2];
-
     entidadeService.addMembro.mockReturnValue({
       id: 11,
       idPerfil: 9,
@@ -63,7 +60,7 @@ describe('EntidadeController', () => {
       classificacao: 'MEMBRO',
     });
 
-    expect(controller.addMembro('1', dto, req)).toEqual({
+    expect(controller.addMembro('1', dto, buildReq())).toEqual({
       id: 11,
       idPerfil: 9,
       idEntidade: 1,
@@ -73,17 +70,13 @@ describe('EntidadeController', () => {
   });
 
   it('should remove members using authenticated manager id', () => {
-    const req: Parameters<EntidadeController['removeMembro']>[2] = {
-      user: { id: '7', email: 'gestor@aluno.unb.br' },
-    } as Parameters<EntidadeController['removeMembro']>[2];
-
     entidadeService.removeMembro.mockReturnValue({
       idEntidade: 1,
       idPerfil: 9,
       removed: true,
     });
 
-    expect(controller.removeMembro('1', '9', req)).toEqual({
+    expect(controller.removeMembro('1', '9', buildReq())).toEqual({
       idEntidade: 1,
       idPerfil: 9,
       removed: true,

--- a/apps/back/src/entidade/entidade.controller.ts
+++ b/apps/back/src/entidade/entidade.controller.ts
@@ -10,16 +10,24 @@ import {
   Request,
   UseGuards,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { EntidadeService } from './entidade.service';
 import { AddMembroDto } from './dto/add-membro.dto';
 import { CreateEntidadeDto } from './dto/create-entidade.dto';
 import { UpdateEntidadeDto } from './dto/update-entidade.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
+type AuthenticatedRequest = ExpressRequest & {
+  user: { id: string; email: string };
+};
+
+@ApiTags('Entidade')
 @Controller('entidade')
 export class EntidadeController {
   constructor(private readonly entidadeService: EntidadeService) {}
 
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
   @Post()
   create(@Body() createEntidadeDto: CreateEntidadeDto) {
     return this.entidadeService.create(createEntidadeDto);
@@ -30,20 +38,20 @@ export class EntidadeController {
     return this.entidadeService.findAll();
   }
 
+  @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @Get('minhas')
-  findMinhasEntidades(
-    @Request() req: ExpressRequest & { user: { id: string; email: string } },
-  ) {
+  findMinhasEntidades(@Request() req: AuthenticatedRequest) {
     return this.entidadeService.findMinhasEntidades(Number(req.user.id));
   }
 
+  @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @Post(':id/membros')
   addMembro(
     @Param('id') id: string,
     @Body() addMembroDto: AddMembroDto,
-    @Request() req: ExpressRequest & { user: { id: string; email: string } },
+    @Request() req: AuthenticatedRequest,
   ) {
     return this.entidadeService.addMembro(
       +id,
@@ -52,12 +60,13 @@ export class EntidadeController {
     );
   }
 
+  @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @Delete(':id/membros/:idPerfil')
   removeMembro(
     @Param('id') id: string,
     @Param('idPerfil') idPerfil: string,
-    @Request() req: ExpressRequest & { user: { id: string; email: string } },
+    @Request() req: AuthenticatedRequest,
   ) {
     return this.entidadeService.removeMembro(
       +id,
@@ -71,6 +80,8 @@ export class EntidadeController {
     return this.entidadeService.findOne(+id);
   }
 
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
   @Patch(':id')
   update(
     @Param('id') id: string,
@@ -79,6 +90,8 @@ export class EntidadeController {
     return this.entidadeService.update(+id, updateEntidadeDto);
   }
 
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.entidadeService.remove(+id);

--- a/apps/back/src/entidade/entidade.controller.ts
+++ b/apps/back/src/entidade/entidade.controller.ts
@@ -1,15 +1,20 @@
+import { Request as ExpressRequest } from 'express';
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
 } from '@nestjs/common';
 import { EntidadeService } from './entidade.service';
+import { AddMembroDto } from './dto/add-membro.dto';
 import { CreateEntidadeDto } from './dto/create-entidade.dto';
 import { UpdateEntidadeDto } from './dto/update-entidade.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @Controller('entidade')
 export class EntidadeController {
@@ -23,6 +28,42 @@ export class EntidadeController {
   @Get()
   findAll() {
     return this.entidadeService.findAll();
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('minhas')
+  findMinhasEntidades(
+    @Request() req: ExpressRequest & { user: { id: string; email: string } },
+  ) {
+    return this.entidadeService.findMinhasEntidades(Number(req.user.id));
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/membros')
+  addMembro(
+    @Param('id') id: string,
+    @Body() addMembroDto: AddMembroDto,
+    @Request() req: ExpressRequest & { user: { id: string; email: string } },
+  ) {
+    return this.entidadeService.addMembro(
+      +id,
+      Number(req.user.id),
+      addMembroDto,
+    );
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete(':id/membros/:idPerfil')
+  removeMembro(
+    @Param('id') id: string,
+    @Param('idPerfil') idPerfil: string,
+    @Request() req: ExpressRequest & { user: { id: string; email: string } },
+  ) {
+    return this.entidadeService.removeMembro(
+      +id,
+      Number(req.user.id),
+      +idPerfil,
+    );
   }
 
   @Get(':id')

--- a/apps/back/src/entidade/entidade.service.spec.ts
+++ b/apps/back/src/entidade/entidade.service.spec.ts
@@ -4,7 +4,7 @@ import {
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
-import { ClassificacaoMembro } from '@prisma/client';
+import { ClassificacaoMembro, Prisma } from '@prisma/client';
 import { EntidadeService } from './entidade.service';
 import { PrismaService } from '../prisma/prisma.service';
 
@@ -25,7 +25,8 @@ describe('EntidadeService', () => {
       findMany: jest.fn(),
       findFirst: jest.fn(),
       create: jest.fn(),
-      deleteMany: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
     },
   };
 
@@ -114,124 +115,301 @@ describe('EntidadeService', () => {
     });
   });
 
-  it('should add a member when requester can manage the entity', async () => {
-    prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-    prisma.membro.findFirst
-      .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
-      .mockResolvedValueOnce(null);
-    prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
-    prisma.membro.create.mockResolvedValue({
-      id: 12,
-      idEntidade: 1,
-      idPerfil: 9,
-      classificacao: 'MEMBRO',
-    });
-
-    await expect(
-      service.addMembro(1, 7, {
-        idPerfil: 9,
-        classificacao: ClassificacaoMembro.MEMBRO,
-      }),
-    ).resolves.toEqual({
-      id: 12,
-      idEntidade: 1,
-      idPerfil: 9,
-      classificacao: 'MEMBRO',
-    });
-
-    expect(prisma.membro.findFirst).toHaveBeenNthCalledWith(1, {
-      where: {
-        idEntidade: 1,
-        idPerfil: 7,
-        classificacao: { in: ['GESTOR', 'CO_GESTOR'] },
-      },
-    });
-    expect(prisma.membro.create).toHaveBeenCalledWith({
-      data: {
+  describe('addMembro', () => {
+    it('should add a MEMBRO when requester is GESTOR', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst.mockResolvedValue({
+        id: 2,
+        classificacao: 'GESTOR',
+      });
+      prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
+      prisma.membro.create.mockResolvedValue({
+        id: 12,
         idEntidade: 1,
         idPerfil: 9,
         classificacao: 'MEMBRO',
-      },
-      include: {
-        perfil: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-          },
-        },
-        entidade: {
-          select: {
-            id: true,
-            nome: true,
-          },
-        },
-      },
-    });
-  });
+      });
 
-  it('should reject adding members when requester cannot manage the entity', async () => {
-    prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-    prisma.membro.findFirst.mockResolvedValue(null);
-
-    await expect(
-      service.addMembro(1, 7, {
-        idPerfil: 9,
-        classificacao: ClassificacaoMembro.MEMBRO,
-      }),
-    ).rejects.toBeInstanceOf(ForbiddenException);
-
-    expect(prisma.membro.create).not.toHaveBeenCalled();
-  });
-
-  it('should reject duplicated entity members', async () => {
-    prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-    prisma.membro.findFirst
-      .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
-      .mockResolvedValueOnce({ id: 12, idPerfil: 9, idEntidade: 1 });
-    prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
-
-    await expect(
-      service.addMembro(1, 7, {
-        idPerfil: 9,
-        classificacao: ClassificacaoMembro.MEMBRO,
-      }),
-    ).rejects.toBeInstanceOf(ConflictException);
-
-    expect(prisma.membro.create).not.toHaveBeenCalled();
-  });
-
-  it('should remove a member when requester can manage the entity', async () => {
-    prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-    prisma.membro.findFirst
-      .mockResolvedValueOnce({ id: 2, classificacao: 'CO_GESTOR' })
-      .mockResolvedValueOnce({ id: 12, idPerfil: 9, idEntidade: 1 });
-    prisma.membro.deleteMany.mockResolvedValue({ count: 1 });
-
-    await expect(service.removeMembro(1, 7, 9)).resolves.toEqual({
-      idEntidade: 1,
-      idPerfil: 9,
-      removed: true,
-    });
-
-    expect(prisma.membro.deleteMany).toHaveBeenCalledWith({
-      where: {
+      await expect(
+        service.addMembro(1, 7, {
+          idPerfil: 9,
+          classificacao: ClassificacaoMembro.MEMBRO,
+        }),
+      ).resolves.toEqual({
+        id: 12,
         idEntidade: 1,
         idPerfil: 9,
-      },
+        classificacao: 'MEMBRO',
+      });
+
+      expect(prisma.membro.findFirst).toHaveBeenCalledWith({
+        where: {
+          idEntidade: 1,
+          idPerfil: 7,
+          classificacao: { in: ['GESTOR', 'CO_GESTOR'] },
+        },
+        select: { id: true, classificacao: true },
+      });
+      expect(prisma.membro.create).toHaveBeenCalledWith({
+        data: {
+          idEntidade: 1,
+          idPerfil: 9,
+          classificacao: 'MEMBRO',
+        },
+        include: {
+          perfil: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+            },
+          },
+          entidade: {
+            select: {
+              id: true,
+              nome: true,
+            },
+          },
+        },
+      });
+    });
+
+    it('should add a MEMBRO when requester is CO_GESTOR', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst.mockResolvedValue({
+        id: 2,
+        classificacao: 'CO_GESTOR',
+      });
+      prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
+      prisma.membro.create.mockResolvedValue({ id: 12 });
+
+      await expect(
+        service.addMembro(1, 7, {
+          idPerfil: 9,
+          classificacao: ClassificacaoMembro.MEMBRO,
+        }),
+      ).resolves.toEqual({ id: 12 });
+
+      expect(prisma.membro.create).toHaveBeenCalled();
+    });
+
+    it('should add a GESTOR when requester is GESTOR', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst.mockResolvedValue({
+        id: 2,
+        classificacao: 'GESTOR',
+      });
+      prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
+      prisma.membro.create.mockResolvedValue({ id: 12 });
+
+      await expect(
+        service.addMembro(1, 7, {
+          idPerfil: 9,
+          classificacao: ClassificacaoMembro.GESTOR,
+        }),
+      ).resolves.toEqual({ id: 12 });
+    });
+
+    it('should reject adding entity members when requester cannot manage', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.addMembro(1, 7, {
+          idPerfil: 9,
+          classificacao: ClassificacaoMembro.MEMBRO,
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(prisma.membro.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject CO_GESTOR trying to create another GESTOR (privilege escalation)', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst.mockResolvedValue({
+        id: 2,
+        classificacao: 'CO_GESTOR',
+      });
+
+      await expect(
+        service.addMembro(1, 7, {
+          idPerfil: 9,
+          classificacao: ClassificacaoMembro.GESTOR,
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(prisma.membro.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject when entity does not exist', async () => {
+      prisma.entidade.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.addMembro(1, 7, {
+          idPerfil: 9,
+          classificacao: ClassificacaoMembro.MEMBRO,
+        }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+
+      expect(prisma.membro.findFirst).not.toHaveBeenCalled();
+      expect(prisma.membro.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject when target perfil does not exist', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst.mockResolvedValue({
+        id: 2,
+        classificacao: 'GESTOR',
+      });
+      prisma.perfil.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.addMembro(1, 7, {
+          idPerfil: 9,
+          classificacao: ClassificacaoMembro.MEMBRO,
+        }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+
+      expect(prisma.membro.create).not.toHaveBeenCalled();
+    });
+
+    it('should map Prisma P2002 (duplicated member) to ConflictException', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst.mockResolvedValue({
+        id: 2,
+        classificacao: 'GESTOR',
+      });
+      prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
+      prisma.membro.create.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: '6.14.0',
+        }),
+      );
+
+      await expect(
+        service.addMembro(1, 7, {
+          idPerfil: 9,
+          classificacao: ClassificacaoMembro.MEMBRO,
+        }),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('should rethrow unexpected errors from prisma.membro.create', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst.mockResolvedValue({
+        id: 2,
+        classificacao: 'GESTOR',
+      });
+      prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
+      const unknownError = new Error('boom');
+      prisma.membro.create.mockRejectedValue(unknownError);
+
+      await expect(
+        service.addMembro(1, 7, {
+          idPerfil: 9,
+          classificacao: ClassificacaoMembro.MEMBRO,
+        }),
+      ).rejects.toBe(unknownError);
     });
   });
 
-  it('should reject removing a member that does not belong to the entity', async () => {
-    prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-    prisma.membro.findFirst
-      .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
-      .mockResolvedValueOnce(null);
+  describe('removeMembro', () => {
+    it('should remove a MEMBRO when requester is CO_GESTOR', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst
+        .mockResolvedValueOnce({ id: 2, classificacao: 'CO_GESTOR' })
+        .mockResolvedValueOnce({ id: 12, classificacao: 'MEMBRO' });
+      prisma.membro.delete.mockResolvedValue({ id: 12 });
 
-    await expect(service.removeMembro(1, 7, 9)).rejects.toBeInstanceOf(
-      NotFoundException,
-    );
+      await expect(service.removeMembro(1, 7, 9)).resolves.toEqual({
+        idEntidade: 1,
+        idPerfil: 9,
+        removed: true,
+      });
 
-    expect(prisma.membro.deleteMany).not.toHaveBeenCalled();
+      expect(prisma.membro.delete).toHaveBeenCalledWith({ where: { id: 12 } });
+    });
+
+    it('should remove a GESTOR when requester is GESTOR and another GESTOR remains', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst
+        .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
+        .mockResolvedValueOnce({ id: 12, classificacao: 'GESTOR' });
+      prisma.membro.count.mockResolvedValue(2);
+      prisma.membro.delete.mockResolvedValue({ id: 12 });
+
+      await expect(service.removeMembro(1, 7, 9)).resolves.toEqual({
+        idEntidade: 1,
+        idPerfil: 9,
+        removed: true,
+      });
+
+      expect(prisma.membro.count).toHaveBeenCalledWith({
+        where: { idEntidade: 1, classificacao: 'GESTOR' },
+      });
+    });
+
+    it('should reject when entity does not exist', async () => {
+      prisma.entidade.findUnique.mockResolvedValue(null);
+
+      await expect(service.removeMembro(1, 7, 9)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+
+      expect(prisma.membro.findFirst).not.toHaveBeenCalled();
+      expect(prisma.membro.delete).not.toHaveBeenCalled();
+    });
+
+    it('should reject when requester cannot manage the entity', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst.mockResolvedValue(null);
+
+      await expect(service.removeMembro(1, 7, 9)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+
+      expect(prisma.membro.delete).not.toHaveBeenCalled();
+    });
+
+    it('should reject removing a member that does not belong to the entity', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst
+        .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
+        .mockResolvedValueOnce(null);
+
+      await expect(service.removeMembro(1, 7, 9)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+
+      expect(prisma.membro.delete).not.toHaveBeenCalled();
+    });
+
+    it('should reject CO_GESTOR trying to remove a GESTOR (hierarchy)', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst
+        .mockResolvedValueOnce({ id: 2, classificacao: 'CO_GESTOR' })
+        .mockResolvedValueOnce({ id: 12, classificacao: 'GESTOR' });
+
+      await expect(service.removeMembro(1, 7, 9)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+
+      expect(prisma.membro.delete).not.toHaveBeenCalled();
+    });
+
+    it('should reject removing the last GESTOR of the entity', async () => {
+      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+      prisma.membro.findFirst
+        .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
+        .mockResolvedValueOnce({ id: 12, classificacao: 'GESTOR' });
+      prisma.membro.count.mockResolvedValue(1);
+
+      await expect(service.removeMembro(1, 7, 9)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+
+      expect(prisma.membro.delete).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/back/src/entidade/entidade.service.spec.ts
+++ b/apps/back/src/entidade/entidade.service.spec.ts
@@ -1,18 +1,237 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import {
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ClassificacaoMembro } from '@prisma/client';
 import { EntidadeService } from './entidade.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 describe('EntidadeService', () => {
   let service: EntidadeService;
+  const prisma = {
+    entidade: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    perfil: {
+      findUnique: jest.fn(),
+    },
+    membro: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [EntidadeService],
+      providers: [
+        EntidadeService,
+        {
+          provide: PrismaService,
+          useValue: prisma,
+        },
+      ],
     }).compile();
 
     service = module.get<EntidadeService>(EntidadeService);
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should list authenticated user entities with membership data', async () => {
+    prisma.membro.findMany.mockResolvedValue([
+      {
+        id: 10,
+        classificacao: 'GESTOR',
+        createdAt: new Date('2026-06-01T00:00:00.000Z'),
+        entidade: {
+          id: 1,
+          nome: 'Conecta UnB',
+          descricao: 'Entidade de teste',
+          classificacao: 'PROJETO_EXTENSAO',
+          campus: 'GAMA',
+          departamento: 'FCTE',
+          linkBanner: null,
+          linkLogo: null,
+          createdAt: new Date('2026-06-01T00:00:00.000Z'),
+          updatedAt: new Date('2026-06-01T00:00:00.000Z'),
+        },
+      },
+    ]);
+
+    await expect(service.findMinhasEntidades(7)).resolves.toEqual([
+      {
+        id: 1,
+        nome: 'Conecta UnB',
+        descricao: 'Entidade de teste',
+        classificacao: 'PROJETO_EXTENSAO',
+        campus: 'GAMA',
+        departamento: 'FCTE',
+        linkBanner: null,
+        linkLogo: null,
+        createdAt: new Date('2026-06-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-06-01T00:00:00.000Z'),
+        vinculo: {
+          id: 10,
+          classificacao: 'GESTOR',
+          createdAt: new Date('2026-06-01T00:00:00.000Z'),
+        },
+      },
+    ]);
+
+    expect(prisma.membro.findMany).toHaveBeenCalledWith({
+      where: { idPerfil: 7 },
+      orderBy: { entidade: { nome: 'asc' } },
+      select: {
+        id: true,
+        classificacao: true,
+        createdAt: true,
+        entidade: {
+          select: {
+            id: true,
+            nome: true,
+            descricao: true,
+            classificacao: true,
+            campus: true,
+            departamento: true,
+            linkBanner: true,
+            linkLogo: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        },
+      },
+    });
+  });
+
+  it('should add a member when requester can manage the entity', async () => {
+    prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+    prisma.membro.findFirst
+      .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
+      .mockResolvedValueOnce(null);
+    prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
+    prisma.membro.create.mockResolvedValue({
+      id: 12,
+      idEntidade: 1,
+      idPerfil: 9,
+      classificacao: 'MEMBRO',
+    });
+
+    await expect(
+      service.addMembro(1, 7, {
+        idPerfil: 9,
+        classificacao: ClassificacaoMembro.MEMBRO,
+      }),
+    ).resolves.toEqual({
+      id: 12,
+      idEntidade: 1,
+      idPerfil: 9,
+      classificacao: 'MEMBRO',
+    });
+
+    expect(prisma.membro.findFirst).toHaveBeenNthCalledWith(1, {
+      where: {
+        idEntidade: 1,
+        idPerfil: 7,
+        classificacao: { in: ['GESTOR', 'CO_GESTOR'] },
+      },
+    });
+    expect(prisma.membro.create).toHaveBeenCalledWith({
+      data: {
+        idEntidade: 1,
+        idPerfil: 9,
+        classificacao: 'MEMBRO',
+      },
+      include: {
+        perfil: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+        entidade: {
+          select: {
+            id: true,
+            nome: true,
+          },
+        },
+      },
+    });
+  });
+
+  it('should reject adding members when requester cannot manage the entity', async () => {
+    prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+    prisma.membro.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.addMembro(1, 7, {
+        idPerfil: 9,
+        classificacao: ClassificacaoMembro.MEMBRO,
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(prisma.membro.create).not.toHaveBeenCalled();
+  });
+
+  it('should reject duplicated entity members', async () => {
+    prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+    prisma.membro.findFirst
+      .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
+      .mockResolvedValueOnce({ id: 12, idPerfil: 9, idEntidade: 1 });
+    prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
+
+    await expect(
+      service.addMembro(1, 7, {
+        idPerfil: 9,
+        classificacao: ClassificacaoMembro.MEMBRO,
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(prisma.membro.create).not.toHaveBeenCalled();
+  });
+
+  it('should remove a member when requester can manage the entity', async () => {
+    prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+    prisma.membro.findFirst
+      .mockResolvedValueOnce({ id: 2, classificacao: 'CO_GESTOR' })
+      .mockResolvedValueOnce({ id: 12, idPerfil: 9, idEntidade: 1 });
+    prisma.membro.deleteMany.mockResolvedValue({ count: 1 });
+
+    await expect(service.removeMembro(1, 7, 9)).resolves.toEqual({
+      idEntidade: 1,
+      idPerfil: 9,
+      removed: true,
+    });
+
+    expect(prisma.membro.deleteMany).toHaveBeenCalledWith({
+      where: {
+        idEntidade: 1,
+        idPerfil: 9,
+      },
+    });
+  });
+
+  it('should reject removing a member that does not belong to the entity', async () => {
+    prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
+    prisma.membro.findFirst
+      .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
+      .mockResolvedValueOnce(null);
+
+    await expect(service.removeMembro(1, 7, 9)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+
+    expect(prisma.membro.deleteMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/back/src/entidade/entidade.service.ts
+++ b/apps/back/src/entidade/entidade.service.ts
@@ -4,7 +4,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { ClassificacaoMembro } from '@prisma/client';
+import { ClassificacaoMembro, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AddMembroDto } from './dto/add-membro.dto';
 import { CreateEntidadeDto } from './dto/create-entidade.dto';
@@ -12,7 +12,7 @@ import { UpdateEntidadeDto } from './dto/update-entidade.dto';
 
 @Injectable()
 export class EntidadeService {
-  constructor(private prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   create(createEntidadeDto: CreateEntidadeDto) {
     return this.prisma.entidade.create({ data: createEntidadeDto });
@@ -74,42 +74,64 @@ export class EntidadeService {
     addMembroDto: AddMembroDto,
   ) {
     await this.ensureEntidadeExists(idEntidade);
-    await this.ensureCanManageEntidade(idEntidade, idPerfilSolicitante);
-    await this.ensurePerfilExists(addMembroDto.idPerfil);
+    const gestaoSolicitante = await this.findGestaoMembro(
+      idEntidade,
+      idPerfilSolicitante,
+    );
 
-    const membroExistente = await this.prisma.membro.findFirst({
-      where: {
-        idEntidade,
-        idPerfil: addMembroDto.idPerfil,
-      },
-    });
-
-    if (membroExistente) {
-      throw new ConflictException('Perfil ja e membro desta entidade');
+    if (!gestaoSolicitante) {
+      throw new ForbiddenException(
+        'Apenas gestores ou co-gestores podem gerenciar membros da entidade',
+      );
     }
 
-    return this.prisma.membro.create({
-      data: {
-        idEntidade,
-        idPerfil: addMembroDto.idPerfil,
-        classificacao: addMembroDto.classificacao,
-      },
-      include: {
-        perfil: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
+    const isPapelDeGestao =
+      addMembroDto.classificacao === ClassificacaoMembro.GESTOR ||
+      addMembroDto.classificacao === ClassificacaoMembro.CO_GESTOR;
+
+    if (
+      isPapelDeGestao &&
+      gestaoSolicitante.classificacao !== ClassificacaoMembro.GESTOR
+    ) {
+      throw new ForbiddenException(
+        'Apenas GESTOR pode atribuir papeis de gestão (GESTOR ou CO_GESTOR)',
+      );
+    }
+
+    await this.ensurePerfilExists(addMembroDto.idPerfil);
+
+    try {
+      return await this.prisma.membro.create({
+        data: {
+          idEntidade,
+          idPerfil: addMembroDto.idPerfil,
+          classificacao: addMembroDto.classificacao,
+        },
+        include: {
+          perfil: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+            },
+          },
+          entidade: {
+            select: {
+              id: true,
+              nome: true,
+            },
           },
         },
-        entidade: {
-          select: {
-            id: true,
-            nome: true,
-          },
-        },
-      },
-    });
+      });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        throw new ConflictException('Perfil já é membro desta entidade');
+      }
+      throw error;
+    }
   }
 
   async removeMembro(
@@ -118,24 +140,58 @@ export class EntidadeService {
     idPerfilRemovido: number,
   ) {
     await this.ensureEntidadeExists(idEntidade);
-    await this.ensureCanManageEntidade(idEntidade, idPerfilSolicitante);
+    const gestaoSolicitante = await this.findGestaoMembro(
+      idEntidade,
+      idPerfilSolicitante,
+    );
 
-    const membro = await this.prisma.membro.findFirst({
-      where: {
-        idEntidade,
-        idPerfil: idPerfilRemovido,
-      },
-    });
-
-    if (!membro) {
-      throw new NotFoundException('Membro nao encontrado nesta entidade');
+    if (!gestaoSolicitante) {
+      throw new ForbiddenException(
+        'Apenas gestores ou co-gestores podem gerenciar membros da entidade',
+      );
     }
 
-    await this.prisma.membro.deleteMany({
+    const alvo = await this.prisma.membro.findFirst({
       where: {
         idEntidade,
         idPerfil: idPerfilRemovido,
       },
+      select: { id: true, classificacao: true },
+    });
+
+    if (!alvo) {
+      throw new NotFoundException('Membro não encontrado nesta entidade');
+    }
+
+    const solicitanteIsGestor =
+      gestaoSolicitante.classificacao === ClassificacaoMembro.GESTOR;
+
+    if (
+      alvo.classificacao === ClassificacaoMembro.GESTOR &&
+      !solicitanteIsGestor
+    ) {
+      throw new ForbiddenException(
+        'CO_GESTOR não pode remover um GESTOR da entidade',
+      );
+    }
+
+    if (alvo.classificacao === ClassificacaoMembro.GESTOR) {
+      const totalGestores = await this.prisma.membro.count({
+        where: {
+          idEntidade,
+          classificacao: ClassificacaoMembro.GESTOR,
+        },
+      });
+
+      if (totalGestores <= 1) {
+        throw new ConflictException(
+          'Não é possível remover o único GESTOR da entidade',
+        );
+      }
+    }
+
+    await this.prisma.membro.delete({
+      where: { id: alvo.id },
     });
 
     return {
@@ -152,7 +208,7 @@ export class EntidadeService {
     });
 
     if (!entidade) {
-      throw new NotFoundException('Entidade nao encontrada');
+      throw new NotFoundException('Entidade não encontrada');
     }
   }
 
@@ -163,12 +219,12 @@ export class EntidadeService {
     });
 
     if (!perfil) {
-      throw new NotFoundException('Perfil nao encontrado');
+      throw new NotFoundException('Perfil não encontrado');
     }
   }
 
-  private async ensureCanManageEntidade(idEntidade: number, idPerfil: number) {
-    const membroGestor = await this.prisma.membro.findFirst({
+  private async findGestaoMembro(idEntidade: number, idPerfil: number) {
+    return this.prisma.membro.findFirst({
       where: {
         idEntidade,
         idPerfil,
@@ -176,12 +232,7 @@ export class EntidadeService {
           in: [ClassificacaoMembro.GESTOR, ClassificacaoMembro.CO_GESTOR],
         },
       },
+      select: { id: true, classificacao: true },
     });
-
-    if (!membroGestor) {
-      throw new ForbiddenException(
-        'Apenas gestores ou co-gestores podem gerenciar membros da entidade',
-      );
-    }
   }
 }

--- a/apps/back/src/entidade/entidade.service.ts
+++ b/apps/back/src/entidade/entidade.service.ts
@@ -1,26 +1,187 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ClassificacaoMembro } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { AddMembroDto } from './dto/add-membro.dto';
 import { CreateEntidadeDto } from './dto/create-entidade.dto';
 import { UpdateEntidadeDto } from './dto/update-entidade.dto';
 
 @Injectable()
 export class EntidadeService {
-  create(_createEntidadeDto: CreateEntidadeDto) {
-    return 'This action adds a new entidade';
+  constructor(private prisma: PrismaService) {}
+
+  create(createEntidadeDto: CreateEntidadeDto) {
+    return this.prisma.entidade.create({ data: createEntidadeDto });
   }
 
   findAll() {
-    return `This action returns all entidade`;
+    return this.prisma.entidade.findMany();
+  }
+
+  async findMinhasEntidades(idPerfil: number) {
+    const vinculos = await this.prisma.membro.findMany({
+      where: { idPerfil },
+      orderBy: { entidade: { nome: 'asc' } },
+      select: {
+        id: true,
+        classificacao: true,
+        createdAt: true,
+        entidade: {
+          select: {
+            id: true,
+            nome: true,
+            descricao: true,
+            classificacao: true,
+            campus: true,
+            departamento: true,
+            linkBanner: true,
+            linkLogo: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        },
+      },
+    });
+
+    return vinculos.map(({ entidade, ...membro }) => ({
+      ...entidade,
+      vinculo: membro,
+    }));
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} entidade`;
+    return this.prisma.entidade.findUnique({ where: { id } });
   }
 
-  update(id: number, _updateEntidadeDto: UpdateEntidadeDto) {
-    return `This action updates a #${id} entidade`;
+  update(id: number, updateEntidadeDto: UpdateEntidadeDto) {
+    return this.prisma.entidade.update({
+      where: { id },
+      data: updateEntidadeDto,
+    });
   }
 
   remove(id: number) {
-    return `This action removes a #${id} entidade`;
+    return this.prisma.entidade.delete({ where: { id } });
+  }
+
+  async addMembro(
+    idEntidade: number,
+    idPerfilSolicitante: number,
+    addMembroDto: AddMembroDto,
+  ) {
+    await this.ensureEntidadeExists(idEntidade);
+    await this.ensureCanManageEntidade(idEntidade, idPerfilSolicitante);
+    await this.ensurePerfilExists(addMembroDto.idPerfil);
+
+    const membroExistente = await this.prisma.membro.findFirst({
+      where: {
+        idEntidade,
+        idPerfil: addMembroDto.idPerfil,
+      },
+    });
+
+    if (membroExistente) {
+      throw new ConflictException('Perfil ja e membro desta entidade');
+    }
+
+    return this.prisma.membro.create({
+      data: {
+        idEntidade,
+        idPerfil: addMembroDto.idPerfil,
+        classificacao: addMembroDto.classificacao,
+      },
+      include: {
+        perfil: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+        entidade: {
+          select: {
+            id: true,
+            nome: true,
+          },
+        },
+      },
+    });
+  }
+
+  async removeMembro(
+    idEntidade: number,
+    idPerfilSolicitante: number,
+    idPerfilRemovido: number,
+  ) {
+    await this.ensureEntidadeExists(idEntidade);
+    await this.ensureCanManageEntidade(idEntidade, idPerfilSolicitante);
+
+    const membro = await this.prisma.membro.findFirst({
+      where: {
+        idEntidade,
+        idPerfil: idPerfilRemovido,
+      },
+    });
+
+    if (!membro) {
+      throw new NotFoundException('Membro nao encontrado nesta entidade');
+    }
+
+    await this.prisma.membro.deleteMany({
+      where: {
+        idEntidade,
+        idPerfil: idPerfilRemovido,
+      },
+    });
+
+    return {
+      idEntidade,
+      idPerfil: idPerfilRemovido,
+      removed: true,
+    };
+  }
+
+  private async ensureEntidadeExists(idEntidade: number) {
+    const entidade = await this.prisma.entidade.findUnique({
+      where: { id: idEntidade },
+      select: { id: true },
+    });
+
+    if (!entidade) {
+      throw new NotFoundException('Entidade nao encontrada');
+    }
+  }
+
+  private async ensurePerfilExists(idPerfil: number) {
+    const perfil = await this.prisma.perfil.findUnique({
+      where: { id: idPerfil },
+      select: { id: true },
+    });
+
+    if (!perfil) {
+      throw new NotFoundException('Perfil nao encontrado');
+    }
+  }
+
+  private async ensureCanManageEntidade(idEntidade: number, idPerfil: number) {
+    const membroGestor = await this.prisma.membro.findFirst({
+      where: {
+        idEntidade,
+        idPerfil,
+        classificacao: {
+          in: [ClassificacaoMembro.GESTOR, ClassificacaoMembro.CO_GESTOR],
+        },
+      },
+    });
+
+    if (!membroGestor) {
+      throw new ForbiddenException(
+        'Apenas gestores ou co-gestores podem gerenciar membros da entidade',
+      );
+    }
   }
 }


### PR DESCRIPTION
## O que foi feito?

- `GET /entidade/minhas`
Lista entidades em que o usuário autenticado é GESTOR, CO_GESTOR ou MEMBRO.

- `POST /entidade/:id/membros`
Adiciona membro, validando que o solicitante autenticado é GESTOR ou CO_GESTOR.

- `DELETE /entidade/:id/membros/:idPerfil`
Remove membro, também validando privilégio de gestão.

-Criação de testes unitários