### PR TITLE
feat: filtros de campus, entidade e departamento no Painel

### DIFF
--- a/apps/front/app/conecta/feed/page.tsx
+++ b/apps/front/app/conecta/feed/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { SlidersHorizontal, X } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import { api } from "@/guards/api";
 import { CAMPUS_OPTIONS, DEPARTAMENTO_OPTIONS } from "@/constants/options";
@@ -108,103 +109,109 @@ export default function HomePage() {
   return (
     <div className="flex min-h-screen bg-gray-50 text-[#1D1D1D]">
       <main className="flex-1 p-8">
-        <div className="max-w-4xl mx-auto bg-white p-8 rounded-xl shadow-md">
-          <div className="flex justify-between items-start gap-4 mb-2">
-            <h1 className="text-3xl font-bold text-[#003366]">
-              Painel do ConectaUnB
-            </h1>
-            <button
-              onClick={logout}
-              className="px-6 py-2 bg-red-600 text-white font-semibold rounded-full hover:bg-red-700 transition-colors"
-            >
-              Sair da Conta
-            </button>
+        <div className="max-w-4xl mx-auto">
+
+          {/* Barra de filtros */}
+          <div className="mb-8 flex flex-wrap items-end gap-x-5 gap-y-3 bg-white border border-gray-200 rounded-xl shadow-sm px-5 py-4">
+            <span className="inline-flex items-center gap-2 text-sm font-semibold text-[#0d2a54] pr-3 border-r border-gray-200 self-center">
+              <SlidersHorizontal size={18} /> Filtros
+            </span>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-xs font-medium text-gray-600">Campus</span>
+              <select
+                name="campus"
+                value={filtros.campus}
+                onChange={handleFiltroChange}
+                className="min-w-[10rem] px-3 py-2 border border-gray-300 rounded-md focus:ring-[#195b3d] focus:border-[#195b3d] outline-none bg-white text-black text-sm"
+              >
+                <option value="">Todos</option>
+                {CAMPUS_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-xs font-medium text-gray-600">Departamento</span>
+              <select
+                name="departamento"
+                value={filtros.departamento}
+                onChange={handleFiltroChange}
+                className="min-w-[10rem] px-3 py-2 border border-gray-300 rounded-md focus:ring-[#195b3d] focus:border-[#195b3d] outline-none bg-white text-black text-sm"
+              >
+                <option value="">Todos</option>
+                {DEPARTAMENTO_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-xs font-medium text-gray-600">Entidade</span>
+              <select
+                name="nome"
+                value={filtros.nome}
+                onChange={handleFiltroChange}
+                className="min-w-[12rem] px-3 py-2 border border-gray-300 rounded-md focus:ring-[#195b3d] focus:border-[#195b3d] outline-none bg-white text-black text-sm"
+              >
+                <option value="">Todas</option>
+                {nomesEntidades.map((nome) => (
+                  <option key={nome} value={nome}>
+                    {nome}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {filtrosAtivos ? (
+              <button
+                type="button"
+                onClick={limparFiltros}
+                className="ml-auto inline-flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+              >
+                <X size={16} /> Limpar
+              </button>
+            ) : null}
           </div>
 
-          <p className="text-gray-600 mb-4">
-            Logado como:{" "}
-            <span className="font-semibold text-green-700">{user.email}</span>
-          </p>
+          {/* Painel */}
+          <div className="bg-white p-8 rounded-xl shadow-md">
+            <div className="flex justify-between items-start gap-4 mb-2">
+              <h1 className="text-3xl font-bold text-[#003366]">
+                Painel do ConectaUnB
+              </h1>
+              <button
+                onClick={logout}
+                className="px-6 py-2 bg-red-600 text-white font-semibold rounded-full hover:bg-red-700 transition-colors"
+              >
+                Sair da Conta
+              </button>
+            </div>
 
-          <div className="p-4 border border-gray-200 rounded-lg mb-8">
-            <h2 className="font-semibold mb-2">Seus Dados de Sessão:</h2>
-            <ul className="list-disc list-inside text-sm text-gray-700 space-y-1">
-              <li><strong>ID no Banco:</strong> {user.sub}</li>
-              <li><strong>Sessão expira em:</strong> {new Date(user.exp * 1000).toLocaleTimeString()}</li>
-            </ul>
+            <p className="text-gray-600 mb-4">
+              Logado como:{" "}
+              <span className="font-semibold text-green-700">{user.email}</span>
+            </p>
+
+            <div className="p-4 border border-gray-200 rounded-lg">
+              <h2 className="font-semibold mb-2">Seus Dados de Sessão:</h2>
+              <ul className="list-disc list-inside text-sm text-gray-700 space-y-1">
+                <li><strong>ID no Banco:</strong> {user.sub}</li>
+                <li><strong>Sessão expira em:</strong> {new Date(user.exp * 1000).toLocaleTimeString()}</li>
+              </ul>
+            </div>
           </div>
-        </div>
 
-        <div className="max-w-4xl mx-auto mt-8">
-          <section className="bg-white p-6 rounded-xl shadow-md">
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="text-2xl font-bold text-[#0d2a54] border-b-2 border-[#195b3d] pb-2">
-                Entidades
-              </h2>
-              {filtrosAtivos ? (
-                <button
-                  type="button"
-                  onClick={limparFiltros}
-                  className="px-4 py-1 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
-                >
-                  Limpar filtros
-                </button>
-              ) : null}
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Campus</label>
-                <select
-                  name="campus"
-                  value={filtros.campus}
-                  onChange={handleFiltroChange}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-[#195b3d] focus:border-[#195b3d] outline-none bg-white text-black"
-                >
-                  <option value="">Todos</option>
-                  {CAMPUS_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Departamento</label>
-                <select
-                  name="departamento"
-                  value={filtros.departamento}
-                  onChange={handleFiltroChange}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-[#195b3d] focus:border-[#195b3d] outline-none bg-white text-black"
-                >
-                  <option value="">Todos</option>
-                  {DEPARTAMENTO_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Entidade</label>
-                <select
-                  name="nome"
-                  value={filtros.nome}
-                  onChange={handleFiltroChange}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-[#195b3d] focus:border-[#195b3d] outline-none bg-white text-black"
-                >
-                  <option value="">Todas</option>
-                  {nomesEntidades.map((nome) => (
-                    <option key={nome} value={nome}>
-                      {nome}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-
+          {/* Entidades */}
+          <section className="mt-8">
+            <h2 className="text-2xl font-bold text-[#0d2a54] mb-6 border-b-2 border-[#195b3d] pb-2">
+              Entidades
+            </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
               {isLoading ? (
                 <p className="text-gray-500">Carregando...</p>

--- a/apps/front/app/conecta/feed/page.tsx
+++ b/apps/front/app/conecta/feed/page.tsx
@@ -1,9 +1,89 @@
 "use client";
 
-import { useAuth } from "@/hooks/useAuth"; 
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/hooks/useAuth";
+import { api } from "@/guards/api";
+import { CAMPUS_OPTIONS, DEPARTAMENTO_OPTIONS } from "@/constants/options";
+import { ProjetoCard } from "@/components/entidade/projetoCard";
+
+type EntidadeResumo = {
+  id: number;
+  nome: string;
+  descricao?: string | null;
+  classificacao?: string;
+  campus?: string;
+  departamento?: string;
+  linkLogo?: string | null;
+};
+
+type Filtros = {
+  campus: string;
+  departamento: string;
+  nome: string;
+};
 
 export default function HomePage() {
   const { user, loading, logout } = useAuth();
+  const router = useRouter();
+
+  const [entidades, setEntidades] = useState<EntidadeResumo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [filtros, setFiltros] = useState<Filtros>({
+    campus: "",
+    departamento: "",
+    nome: "",
+  });
+
+  const fetchEntidades = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await api.get("/entidade");
+      setEntidades(response.data);
+    } catch (error) {
+      console.error("Erro ao buscar entidades:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchEntidades();
+  }, [fetchEntidades]);
+
+  const nomesEntidades = useMemo(() => {
+    const nomes = entidades
+      .map((e) => e.nome)
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b));
+    return Array.from(new Set(nomes));
+  }, [entidades]);
+
+  const entidadesFiltradas = useMemo(() => {
+    return entidades.filter((entidade) => {
+      if (filtros.campus && entidade.campus !== filtros.campus) return false;
+      if (filtros.departamento && entidade.departamento !== filtros.departamento)
+        return false;
+      if (filtros.nome && entidade.nome !== filtros.nome) return false;
+      return true;
+    });
+  }, [entidades, filtros]);
+
+  const filtrosAtivos =
+    Boolean(filtros.campus) ||
+    Boolean(filtros.departamento) ||
+    Boolean(filtros.nome);
+
+  const handleFiltroChange = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    const { name, value } = event.target;
+    setFiltros((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const limparFiltros = () => {
+    setFiltros({ campus: "", departamento: "", nome: "" });
+  };
 
   if (loading) {
     return (
@@ -29,14 +109,21 @@ export default function HomePage() {
     <div className="flex min-h-screen bg-gray-50 text-[#1D1D1D]">
       <main className="flex-1 p-8">
         <div className="max-w-4xl mx-auto bg-white p-8 rounded-xl shadow-md">
-          
-          <h1 className="text-3xl font-bold text-[#003366] mb-2">
-            Painel do ConectaUnB
-          </h1>
-          
-          {/* Acessando os dados extraídos do Token */}
-          <p className="text-gray-600 mb-6">
-            Logado como: <span className="font-semibold text-green-700">{user.email}</span>
+          <div className="flex justify-between items-start gap-4 mb-2">
+            <h1 className="text-3xl font-bold text-[#003366]">
+              Painel do ConectaUnB
+            </h1>
+            <button
+              onClick={logout}
+              className="px-6 py-2 bg-red-600 text-white font-semibold rounded-full hover:bg-red-700 transition-colors"
+            >
+              Sair da Conta
+            </button>
+          </div>
+
+          <p className="text-gray-600 mb-4">
+            Logado como:{" "}
+            <span className="font-semibold text-green-700">{user.email}</span>
           </p>
 
           <div className="p-4 border border-gray-200 rounded-lg mb-8">
@@ -46,15 +133,97 @@ export default function HomePage() {
               <li><strong>Sessão expira em:</strong> {new Date(user.exp * 1000).toLocaleTimeString()}</li>
             </ul>
           </div>
+        </div>
 
-          {/* Usando a função de logout do Hook */}
-          <button
-            onClick={logout}
-            className="px-6 py-2 bg-red-600 text-white font-semibold rounded-full hover:bg-red-700 transition-colors"
-          >
-            Sair da Conta
-          </button>
+        <div className="max-w-4xl mx-auto mt-8">
+          <section className="bg-white p-6 rounded-xl shadow-md">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-2xl font-bold text-[#0d2a54] border-b-2 border-[#195b3d] pb-2">
+                Entidades
+              </h2>
+              {filtrosAtivos ? (
+                <button
+                  type="button"
+                  onClick={limparFiltros}
+                  className="px-4 py-1 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+                >
+                  Limpar filtros
+                </button>
+              ) : null}
+            </div>
 
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Campus</label>
+                <select
+                  name="campus"
+                  value={filtros.campus}
+                  onChange={handleFiltroChange}
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-[#195b3d] focus:border-[#195b3d] outline-none bg-white text-black"
+                >
+                  <option value="">Todos</option>
+                  {CAMPUS_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Departamento</label>
+                <select
+                  name="departamento"
+                  value={filtros.departamento}
+                  onChange={handleFiltroChange}
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-[#195b3d] focus:border-[#195b3d] outline-none bg-white text-black"
+                >
+                  <option value="">Todos</option>
+                  {DEPARTAMENTO_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Entidade</label>
+                <select
+                  name="nome"
+                  value={filtros.nome}
+                  onChange={handleFiltroChange}
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-[#195b3d] focus:border-[#195b3d] outline-none bg-white text-black"
+                >
+                  <option value="">Todas</option>
+                  {nomesEntidades.map((nome) => (
+                    <option key={nome} value={nome}>
+                      {nome}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+              {isLoading ? (
+                <p className="text-gray-500">Carregando...</p>
+              ) : entidadesFiltradas.length > 0 ? (
+                entidadesFiltradas.map((entidade) => (
+                  <ProjetoCard
+                    key={entidade.id}
+                    nome={entidade.nome}
+                    descricao={entidade.descricao ?? ""}
+                    imagem={entidade.linkLogo || undefined}
+                    onClick={() => router.push(`/conecta/entidades/${entidade.id}`)}
+                    vinculo="MEMBRO"
+                  />
+                ))
+              ) : (
+                <p className="text-gray-500">Nenhuma entidade encontrada para os filtros.</p>
+              )}
+            </div>
+          </section>
         </div>
       </main>
     </div>

--- a/apps/front/hooks/useAuth.ts
+++ b/apps/front/hooks/useAuth.ts
@@ -9,35 +9,30 @@ interface TokenPayload {
   exp: number;
 }
 
+function readToken(): TokenPayload | null {
+  if (typeof window === "undefined") return null;
+  const token = localStorage.getItem("conecta_unb_token");
+  if (!token) return null;
+  try {
+    const decoded = jwtDecode<TokenPayload>(token);
+    if (decoded.exp < Date.now() / 1000) {
+      localStorage.removeItem("conecta_unb_token");
+      return null;
+    }
+    return decoded;
+  } catch {
+    localStorage.removeItem("conecta_unb_token");
+    return null;
+  }
+}
+
 export function useAuth() {
-  const [user, setUser] = useState<TokenPayload | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [user, setUser] = useState<TokenPayload | null>(readToken);
+  const [loading, setLoading] = useState(() => typeof window === "undefined");
   const router = useRouter();
 
   const checkToken = useCallback(() => {
-    const token = localStorage.getItem("conecta_unb_token");
-
-    if (token) {
-      try {
-        const decoded = jwtDecode<TokenPayload>(token);
-        const tempoAtual = Date.now() / 1000;
-        
-        if (decoded.exp < tempoAtual) {
-          console.warn("Sessão expirada. Removendo token...");
-          localStorage.removeItem("conecta_unb_token");
-          setUser(null);
-        } else {
-          setUser(decoded);
-        }
-      } catch {
-        console.error("Token inválido ou corrompido.");
-        localStorage.removeItem("conecta_unb_token");
-        setUser(null);
-      }
-    } else {
-      setUser(null);
-    }
-    
+    setUser(readToken());
     setLoading(false);
   }, []);
 

--- a/apps/front/hooks/useAuth.ts
+++ b/apps/front/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import { jwtDecode } from "jwt-decode";
 import { useRouter } from "next/navigation";
 
@@ -9,55 +9,71 @@ interface TokenPayload {
   exp: number;
 }
 
-function readToken(): TokenPayload | null {
-  if (typeof window === "undefined") return null;
+type AuthState =
+  | { status: "loading" }
+  | { status: "unauthenticated" }
+  | { status: "authenticated"; user: TokenPayload };
+
+const LOADING_STATE: AuthState = { status: "loading" };
+const UNAUTH_STATE: AuthState = { status: "unauthenticated" };
+
+let clientCache: AuthState | null = null;
+
+function computeAuthState(): AuthState {
   const token = localStorage.getItem("conecta_unb_token");
-  if (!token) return null;
+  if (!token) return UNAUTH_STATE;
   try {
     const decoded = jwtDecode<TokenPayload>(token);
     if (decoded.exp < Date.now() / 1000) {
       localStorage.removeItem("conecta_unb_token");
-      return null;
+      return UNAUTH_STATE;
     }
-    return decoded;
+    return { status: "authenticated", user: decoded };
   } catch {
     localStorage.removeItem("conecta_unb_token");
-    return null;
+    return UNAUTH_STATE;
   }
 }
 
+function getSnapshot(): AuthState {
+  if (clientCache === null) {
+    clientCache = computeAuthState();
+  }
+  return clientCache;
+}
+
+function getServerSnapshot(): AuthState {
+  return LOADING_STATE;
+}
+
+function subscribe(callback: () => void): () => void {
+  const handler = () => {
+    clientCache = null;
+    callback();
+  };
+
+  window.addEventListener("auth_changed", handler);
+  window.addEventListener("storage", handler);
+
+  return () => {
+    window.removeEventListener("auth_changed", handler);
+    window.removeEventListener("storage", handler);
+  };
+}
+
 export function useAuth() {
-  const [user, setUser] = useState<TokenPayload | null>(readToken);
-  const [loading, setLoading] = useState(() => typeof window === "undefined");
   const router = useRouter();
-
-  const checkToken = useCallback(() => {
-    setUser(readToken());
-    setLoading(false);
-  }, []);
-
-  useEffect(() => {
-
-    checkToken();
-
-    window.addEventListener("auth_changed", checkToken);
-    
-    window.addEventListener("storage", checkToken);
-
-    return () => {
-      window.removeEventListener("auth_changed", checkToken);
-      window.removeEventListener("storage", checkToken);
-    };
-  }, [checkToken]);
+  const state = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   const logout = useCallback(() => {
     localStorage.removeItem("conecta_unb_token");
-    setUser(null);
-    
-    window.dispatchEvent(new Event("auth_changed")); 
-    
+    clientCache = null;
+    window.dispatchEvent(new Event("auth_changed"));
     router.push("/conecta/feed");
   }, [router]);
+
+  const user = state.status === "authenticated" ? state.user : null;
+  const loading = state.status === "loading";
 
   return { user, loading, logout };
 }

--- a/apps/front/package.json
+++ b/apps/front/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3001",
+    "dev": "next dev -p 3001 --webpack",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
## Resumo
Adiciona uma **barra de filtros** (Campus, Departamento e Entidade) na tela do Painel do ConectaUnB, com a listagem de entidades filtráveis, além de correções de estabilidade no hook de autenticação e no dev server.

## Mudanças
- **Painel (\`apps/front/app/conecta/feed/page.tsx\`)**
  - Busca entidades via \`GET /entidade\` e exibe em grid de cards reutilizando \`ProjetoCard\`.
  - Barra de filtros horizontal acima do card do Painel: **Campus**, **Departamento** e **Entidade** (dropdown com os nomes), com botão **Limpar**.
  - Estados de loading e vazio tratados.
- **Auth (\`apps/front/hooks/useAuth.ts\`)**
  - Refatorado para \`useSyncExternalStore\`: elimina o **flicker** do "Carregando perfil..." (Strict Mode) e o **hydration mismatch** (server/client).
  - Mesma assinatura \`{ user, loading, logout }\` — nenhum caller precisou mudar.
- **Dev (\`apps/front/package.json\`)**
  - Script \`dev\` agora usa \`--webpack\`, evitando os panics recorrentes do Turbopack (Next 16.2.6) neste projeto.

## Como testar
1. \`pnpm dev\` (porta 3001).
2. Logar e acessar o Painel; confirmar que a barra de filtros aparece acima do card e filtra as entidades.
3. Acessar \`/\` e \`/conecta/feed\` logado/deslogado; confirmar ausência de erro de hydration no console.

## Commits
- feat: filtros de campus, entidade e departamento no Painel
- design: filtros como barra horizontal acima do Painel
- fix(useAuth): ler token de forma sincrona para evitar flicker do loading
- fix(useAuth): usar useSyncExternalStore para evitar hydration mismatch
- chore(front): usar webpack no dev para evitar panics do Turbopack