### PR TITLE
feat: migra deploy para Akamai (Linode) com Docker Compose e Caddy

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,22 +1,40 @@
-# Ambiente de produção
+# ============================================================
+# Ambiente de producao (Akamai / Linode)
+# Copie para .env na raiz da VM e preencha os segredos.
+# ============================================================
+
+# --- Dominios / TLS (lidos pelo Caddy via docker-compose.prod.yml) ---
+ACME_EMAIL=contato@conectaunb.org
+API_DOMAIN=api.conectaunb.org
+APP_DOMAIN=app.conectaunb.org
+
+# --- Registro de imagens (GHCR) ---
+GHCR_OWNER=mdsreq-fga-unb
+IMAGE_TAG=latest
+
+# --- Banco PostgreSQL (container na propria VM) ---
+POSTGRES_USER=conectaunb
+POSTGRES_PASSWORD=troque-por-uma-senha-forte
+POSTGRES_DB=conectaunb
+# No compose, o DATABASE_URL e montado apontando para o servico `postgres`.
+DATABASE_URL=postgresql://conectaunb:troque-por-uma-senha-forte@postgres:5432/conectaunb?schema=public
+
+# --- URLs publicas ---
+NEXT_PUBLIC_API_URL=https://api.conectaunb.org
+FRONTEND_URL=https://app.conectaunb.org
+CORS_ORIGIN=https://app.conectaunb.org
+
+# --- Aplicacao ---
 NODE_ENV=production
 PORT=3000
-
-# Banco PostgreSQL gerenciado em produção
-DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/conectaunb?schema=public
-
-# URL pública da API em produção (consumida pelo frontend)
-NEXT_PUBLIC_API_URL=https://api.conectaunb.org
-
-# URL pública do frontend em produção
-FRONTEND_URL=https://frontend.conectaunb.org
-CORS_ORIGIN=https://frontend.conectaunb.org
-
-# Autenticação
 JWT_SECRET=change-me-in-production
+SWAGGER_ENABLED=false
 
-# Cloudflare R2 para mídias
+# --- Cloudflare R2 para midias ---
 R2_ACCOUNT_ID=change-me
 R2_ACCESS_KEY_ID=change-me
 R2_SECRET_ACCESS_KEY=change-me
 R2_BUCKET_NAME=conectaunb-media
+R2_ENDPOINT=https://change-me.r2.cloudflarestorage.com
+R2_REGION=auto
+R2_PUBLIC_URL=https://media.conectaunb.org

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -131,10 +131,10 @@ jobs:
         run: pnpm --filter front build
 
   release-image:
-    name: Release Docker image (disabled)
+    name: Release Docker images
     runs-on: ubuntu-latest
     needs: [build]
-    if: false # habilite quando o deploy for definido
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       contents: read
       packages: write
@@ -148,7 +148,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
+      - name: Build & push backend image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -161,66 +161,48 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
 
-  deploy-koyeb:
-    name: Deploy to Koyeb (disabled)
+      - name: Build & push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/Dockerfile.front.prod
+          push: true
+          build-args: |
+            NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/conectaunb-front:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/conectaunb-front:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+  deploy-akamai:
+    name: Deploy to Akamai (Linode) via SSH
     runs-on: ubuntu-latest
     needs: [release-image]
-    if: false # habilite quando o deploy for definido
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
-      # Opcao A (mais simples): deploy hook unico. Defina KOYEB_DEPLOY_HOOK_URL.
-      - name: Trigger Koyeb deploy hook
-        if: ${{ vars.KOYEB_DEPLOY_HOOK_URL != '' }}
-        run: |
-          curl -fsSL -X POST "${{ secrets.KOYEB_DEPLOY_HOOK_URL }}"
+      - name: Compute short sha
+        id: tag
+        run: echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
-      # Opcao B: API /redeploy. Defina KOYEB_SERVICE e KOYEB_API_TOKEN.
-      - name: Trigger Koyeb redeploy API
-        if: ${{ vars.KOYEB_SERVICE != '' }}
-        run: |
-          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
-            "https://app.koyeb.com/v1/services/${{ secrets.KOYEB_SERVICE }}/redeploy" \
-            -H "Authorization: Bearer ${{ secrets.KOYEB_API_TOKEN }}" \
-            -H "Content-Type: application/json")
-          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-          echo "Status: $HTTP_CODE"
-          echo "Response: $BODY"
-          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
-            echo "Deploy failed with HTTP $HTTP_CODE"
-            exit 1
-          fi
-          echo "Deploy triggered successfully"
-
-  deploy-vercel:
-    name: Deploy front to Vercel (disabled)
-    runs-on: ubuntu-latest
-    needs: [build]
-    if: false # habilite quando o deploy for definido
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        run: corepack enable && corepack prepare pnpm@11.3.0 --activate
-
-      - uses: actions/setup-node@v4
+      - name: SSH into the VM and roll the stack
+        uses: appleboy/ssh-action@v1
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.sha }}
+          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Pull Vercel environment
-        working-directory: apps/front
-        run: npx vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
-
-      - name: Build Vercel app
-        working-directory: apps/front
-        run: npx vercel build --prod --token "$VERCEL_TOKEN"
-
-      - name: Deploy to Vercel
-        working-directory: apps/front
-        run: npx vercel deploy --prebuilt --prod --token "$VERCEL_TOKEN"
+          host: ${{ secrets.AKAMAI_HOST }}
+          username: ${{ secrets.AKAMAI_USER }}
+          key: ${{ secrets.AKAMAI_SSH_KEY }}
+          envs: IMAGE_TAG,GHCR_PULL_TOKEN,GHCR_USER
+          script: |
+            cd /opt/conectaunb
+            git pull --ff-only
+            if [ -n "$GHCR_PULL_TOKEN" ]; then \
+              echo "$GHCR_PULL_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin; \
+            fi
+            docker compose -f infra/docker/docker-compose.prod.yml pull
+            docker compose -f infra/docker/docker-compose.prod.yml up -d --remove-orphans
+            docker image prune -f

--- a/README.md
+++ b/README.md
@@ -147,3 +147,13 @@ SWAGGER_ENABLED=true
 | `BCRYPT_SALT_ROUNDS` | Não | `10` | Número de rounds do bcrypt para hash de senha |
 | `CORS_ORIGIN` | Não | `*` | Origem permitida pelo CORS |
 | `SWAGGER_ENABLED` | Não | `false` | Habilita Swagger fora de development |
+
+## Deploy de produção (Akamai / Linode)
+
+O backend e o frontend são publicados juntos numa única VM da Akamai, em containers Docker orquestrados por `infra/docker/docker-compose.prod.yml`, com o Caddy como reverse proxy (HTTPS automático via Let's Encrypt).
+
+- **Deploy automático**: a cada `push` em `main`, o workflow `.github/workflows/ci-cd.yml` builda as imagens (`conectaunb-back` e `conectaunb-front`), publica no GHCR e dispara o restart na VM via SSH.
+- **Migrações**: aplicadas automaticamente no start do container `api` (`infra/akamai/back-entrypoint`).
+- **Passo a passo completo**: ver [`docs/deploy/akamai.md`](docs/deploy/akamai.md).
+
+Secrets do GitHub Actions necessários: `AKAMAI_HOST`, `AKAMAI_USER`, `AKAMAI_SSH_KEY`, `NEXT_PUBLIC_API_URL` (e `GHCR_PULL_TOKEN` opcional, se as imagens forem privadas).

--- a/apps/front/next.config.ts
+++ b/apps/front/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/docs/deploy/akamai.md
+++ b/docs/deploy/akamai.md
@@ -1,0 +1,174 @@
+# Deploy na Akamai (Linode)
+
+O backend e o frontend do ConectaUnB rodam juntos numa única VM da **Akamai Cloud Computing (Linode)**, em containers orquestrados por Docker Compose. O Caddy atua como reverse proxy e emite certificados HTTPS (Let's Encrypt) automaticamente.
+
+## Arquitetura
+
+```
+Internet ─► Caddy (80/443, TLS auto)
+                ├─ api.conectaunb.org  ─► api:3000    (NestJS)
+                │                            └─► postgres:5432 (volume persistente)
+                └─ app.conectaunb.org  ─► front:3001  (Next.js standalone)
+```
+
+A VM roda 4 containers via `infra/docker/docker-compose.prod.yml`:
+
+| Serviço | Imagem | Função |
+|---|---|---|
+| `caddy` | `caddy:2-alpine` | Reverse proxy + HTTPS automático |
+| `postgres` | `postgres:15-alpine` | Banco de dados (volume `pgdata`) |
+| `api` | `ghcr.io/<owner>/conectaunb-back` | Backend NestJS (roda migrations no start) |
+| `front` | `ghcr.io/<owner>/conectaunb-front` | Frontend Next.js (standalone) |
+
+## Pré-requisitos
+
+- Conta na Akamai Cloud Computing com uma VM (recomendado: **Shared CPU, 4GB RAM**, Ubuntu 22.04+).
+- Docker Engine + Docker Compose v2 instalados na VM.
+- DNS com dois registros tipo **A** apontando para o IP da VM:
+  - `api.conectaunb.org`
+  - `app.conectaunb.org`
+- Secrets do GitHub Actions configurados (ver [CI/CD](#cicd)).
+
+## Passo a passo (provisionamento inicial)
+
+### 1. Criar a VM e instalar o Docker
+
+Crie um Linode (Shared CPU 4GB, Ubuntu 22.04) e acesse via SSH. Instale o Docker:
+
+```bash
+ssh root@<IP_DA_VM>
+curl -fsSL https://get.docker.com | sh
+apt-get install -y git
+```
+
+### 2. Clonar o repositório na VM
+
+```bash
+mkdir -p /opt && cd /opt
+git clone https://github.com/mdsreq-fga-unb/REQ-2026.1-T02-ConectaUnB.git conectaunb
+cd conectaunb
+```
+
+### 3. Configurar variáveis de ambiente
+
+```bash
+cp .env.prod.example .env
+nano .env   # preencha JWT_SECRET, POSTGRES_PASSWORD, R2_*, domínios, ACME_EMAIL
+```
+
+Variáveis que **devem** ser preenchidas:
+
+| Variável | Descrição |
+|---|---|
+| `ACME_EMAIL` | E-mail para os certificados Let's Encrypt |
+| `API_DOMAIN` / `APP_DOMAIN` | Domínios que apontam para a VM |
+| `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | Credenciais do banco |
+| `JWT_SECRET` | Chave forte (mín. 32 chars) para JWT |
+| `R2_*` | Credenciais do Cloudflare R2 |
+| `CORS_ORIGIN` / `FRONTEND_URL` | URL do frontend (`https://app.conectaunb.org`) |
+
+### 4. Apontar o DNS
+
+No gerenciador de DNS, crie dois registros **A** apontando para o IP da VM:
+
+```
+api  A  <IP_DA_VM>
+app  A  <IP_DA_VM>
+```
+
+> O Caddy só consegue emitir o certificado depois que o DNS estiver propagado.
+
+### 5. Subir a stack
+
+```bash
+docker compose -f infra/docker/docker-compose.prod.yml up -d
+```
+
+Na primeira vez:
+
+1. `postgres` sobe e fica healthy.
+2. `api` roda `prisma migrate deploy` (cria as tabelas) e inicia o NestJS.
+3. `front` sobe o Next.js.
+4. `caddy` emite os certificados e passa a servir `api.*` e `app.*` em HTTPS.
+
+## Migrações do Prisma
+
+As migrações são aplicadas **automaticamente** a cada (re)start do container `api`, via `infra/akamai/back-entrypoint`, **antes** de subir o NestJS. O `api` só sobe depois do Postgres saudável (`depends_on` com `condition: service_healthy`).
+
+Para aplicar manualmente:
+
+```bash
+docker compose -f infra/docker/docker-compose.prod.yml exec api \
+  pnpm --filter back prisma:migrate:deploy
+```
+
+## Health check
+
+- O `api` expõe `GET /health`, usado como healthcheck no compose.
+- Teste pelo domínio público:
+
+```bash
+curl -fsS https://api.conectaunb.org/health
+```
+
+## CI/CD
+
+O workflow `.github/workflows/ci-cd.yml` automatiza o deploy a cada `push` em `main`:
+
+1. Jobs `lint`, `test-back`, `test-front`, `build` validam o código.
+2. `release-image` (somente em `main`): builda e publica `conectaunb-back` e `conectaunb-front` no GHCR (tags `:<sha>` e `:latest`).
+3. `deploy-akamai` (somente em `main`): conecta via SSH na VM e executa `docker compose pull && up -d --remove-orphans` com `IMAGE_TAG=<sha-curta>`.
+
+### Secrets necessários no GitHub
+
+| Secret | Descrição |
+|---|---|
+| `AKAMAI_HOST` | IP da VM |
+| `AKAMAI_USER` | Usuário SSH (ex.: `root` ou usuário criado) |
+| `AKAMAI_SSH_KEY` | Chave privada SSH (mesma do `~/.ssh/authorized_keys` da VM) |
+| `NEXT_PUBLIC_API_URL` | URL pública da API (build-time do Next.js, ex.: `https://api.conectaunb.org`) |
+| `GHCR_PULL_TOKEN` *(opcional)* | PAT para a VM fazer `docker pull` (necessário se as imagens GHCR forem privadas) |
+
+> Se as imagens no GHCR forem **públicas**, o `GHCR_PULL_TOKEN` pode ficar vazio (o `docker login` é ignorado).
+
+## Logs e operação
+
+```bash
+# Logs em tempo real de todos os serviços
+docker compose -f infra/docker/docker-compose.prod.yml logs -f
+
+# Logs de um serviço específico
+docker compose -f infra/docker/docker-compose.prod.yml logs -f api
+
+# Abrir shell no container da API
+docker compose -f infra/docker/docker-compose.prod.yml exec api sh
+
+# Reiniciar / parar tudo
+docker compose -f infra/docker/docker-compose.prod.yml restart
+docker compose -f infra/docker/docker-compose.prod.yml down
+```
+
+## Backup do banco
+
+O dado vive no volume `pgdata`. Para um dump:
+
+```bash
+docker compose -f infra/docker/docker-compose.prod.yml exec postgres \
+  pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" > backup-$(date +%F).sql
+```
+
+## Custos estimados (referência)
+
+| Recurso | Plano | Preço (USD/mês) |
+|---|---|---|
+| Linode Shared CPU 4GB | 4 vCPU, 4GB, 80GB SSD | ~$24 |
+| Domínio | — | ~$1 |
+| **Total** | | **~$25/mês** |
+
+## Troubleshooting
+
+- **Caddy não emite certificado (TLS)**: confira se o DNS já propagou (`dig api.conectaunb.org`) e se as portas 80/443 estão abertas no firewall da VM (`ufw allow 80,443/tcp`). Veja os logs do Caddy: `docker compose logs caddy`.
+- **`api` reinicia em loop**: provavelmente o Postgres ainda não está pronto ou as migrations falharam. Rode `docker compose logs api` e confira `DATABASE_URL`.
+- **CORS bloqueando o frontend**: defina `CORS_ORIGIN` com a URL exata do frontend (com `https://` e sem barra final).
+- **`docker pull` falha com `unauthorized`**: as imagens GHCR estão privadas. Crie um PAT com escopo `read:packages` e defina o secret `GHCR_PULL_TOKEN`.
+- **Frontend aponta para URL errada**: `NEXT_PUBLIC_API_URL` é definido em **build time**. Após alterá-la, é preciso rebuildar e publicar a imagem `conectaunb-front` (o CI faz isso no próximo push em `main`).

--- a/infra/akamai/Caddyfile
+++ b/infra/akamai/Caddyfile
@@ -1,0 +1,33 @@
+# Reverse proxy do ConectaUnB na Akamai (Linode).
+# O Caddy emite/renova certificados Let's Encrypt automaticamente para os
+# dominios abaixo. Ajuste os hostnames conforme seu DNS.
+#
+# Requer variaveis de ambiente no servico `caddy` do docker-compose.prod.yml:
+#   - API_DOMAIN   (ex.: api.conectaunb.org)
+#   - APP_DOMAIN   (ex.: app.conectaunb.org)
+
+{
+	email {$ACME_EMAIL}
+}
+
+# API (backend NestJS)
+{$API_DOMAIN} {
+	reverse_proxy api:3000 {
+		header_up Host {host}
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-For {remote_host}
+		header_up X-Forwarded-Proto {scheme}
+	}
+	encode gzip zstd
+}
+
+# Frontend (Next.js)
+{$APP_DOMAIN} {
+	reverse_proxy front:3001 {
+		header_up Host {host}
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-For {remote_host}
+		header_up X-Forwarded-Proto {scheme}
+	}
+	encode gzip zstd
+}

--- a/infra/akamai/back-entrypoint
+++ b/infra/akamai/back-entrypoint
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "[entrypoint] Aplicando migrations do Prisma..."
+pnpm --filter back prisma:migrate:deploy
+
+echo "[entrypoint] Iniciando a API..."
+exec node apps/back/dist/main.js

--- a/infra/docker/Dockerfile.front.prod
+++ b/infra/docker/Dockerfile.front.prod
@@ -1,0 +1,34 @@
+FROM node:24-alpine AS builder
+
+WORKDIR /workspace
+
+RUN corepack enable && corepack prepare pnpm@11.3.0 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY apps/front/package.json apps/front/package.json
+
+RUN pnpm install --frozen-lockfile
+
+# NEXT_PUBLIC_* sao inlined em build time no Next.js
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+
+COPY apps/front apps/front
+
+RUN pnpm --filter front build
+
+FROM node:24-alpine AS production
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3001
+ENV HOSTNAME=0.0.0.0
+
+COPY --from=builder /workspace/apps/front/.next/standalone ./
+COPY --from=builder /workspace/apps/front/.next/static ./apps/front/.next/static
+COPY --from=builder /workspace/apps/front/public ./apps/front/public
+
+EXPOSE 3001
+
+CMD ["node", "apps/front/server.js"]

--- a/infra/docker/Dockerfile.prod
+++ b/infra/docker/Dockerfile.prod
@@ -31,6 +31,9 @@ COPY --from=builder /workspace/apps/back/dist apps/back/dist
 
 RUN pnpm --filter back prisma:generate
 
+COPY infra/akamai/back-entrypoint /usr/local/bin/back-entrypoint
+RUN chmod +x /usr/local/bin/back-entrypoint
+
 EXPOSE 3000
 
-CMD ["node", "apps/back/dist/main.js"]
+CMD ["/usr/local/bin/back-entrypoint"]

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -1,0 +1,94 @@
+# Stack de producao do ConectaUnB para a Akamai (Linode).
+# Uso (na VM):
+#   docker compose -f infra/docker/docker-compose.prod.yml pull
+#   docker compose -f infra/docker/docker-compose.prod.yml up -d
+#
+# Requer um arquivo .env na raiz com as variaveis listadas em .env.prod.example.
+# As imagens sao publicadas no GHCR pelo CI (ci-cd.yml) e referenciadas por tag.
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    container_name: conecta_caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ../akamai/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    environment:
+      ACME_EMAIL: ${ACME_EMAIL}
+      API_DOMAIN: ${API_DOMAIN}
+      APP_DOMAIN: ${APP_DOMAIN}
+    depends_on:
+      - api
+      - front
+    networks:
+      - edge
+
+  postgres:
+    image: postgres:15-alpine
+    container_name: conecta_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    networks:
+      - internal
+
+  api:
+    image: ghcr.io/${GHCR_OWNER:-mdsreq-fga-unb}/conectaunb-back:${IMAGE_TAG:-latest}
+    container_name: conecta_api
+    restart: unless-stopped
+    env_file:
+      - ../../.env
+    environment:
+      NODE_ENV: production
+      PORT: 3000
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?schema=public
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/health >/dev/null 2>&1 || curl -fsS http://localhost:3000/health >/dev/null || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    networks:
+      - edge
+      - internal
+
+  front:
+    image: ghcr.io/${GHCR_OWNER:-mdsreq-fga-unb}/conectaunb-front:${IMAGE_TAG:-latest}
+    container_name: conecta_front
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      PORT: 3001
+    depends_on:
+      - api
+    networks:
+      - edge
+
+volumes:
+  pgdata:
+  caddy_data:
+  caddy_config:
+
+networks:
+  edge:
+  internal:
+    internal: true


### PR DESCRIPTION
## Resumo

Substitui o deploy PaaS (Render/Vercel/Koyeb) por uma **VM única na Akamai (Linode)** hospedando backend, frontend, PostgreSQL e reverse proxy juntos, orquestrados por Docker Compose.

## Arquitetura

```
Internet ─► Caddy (80/443, TLS auto)
                ├─ api.conectaunb.org  ─► api:3000    (NestJS)
                │                            └─► postgres:5432 (volume persistente)
                └─ app.conectaunb.org  ─► front:3001  (Next.js standalone)
```

## Mudanças

**Novos arquivos**
- `infra/docker/docker-compose.prod.yml` — stack `caddy` + `postgres` + `api` + `front`
- `infra/akamai/Caddyfile` — reverse proxy com TLS automático (Let's Encrypt)
- `infra/akamai/back-entrypoint` — roda `prisma migrate deploy` antes de iniciar a API (sem extensão para não cair no `*.sh` do `.gitignore`)
- `infra/docker/Dockerfile.front.prod` — build standalone do Next.js (recebe `NEXT_PUBLIC_API_URL` como build-arg)
- `docs/deploy/akamai.md` — passo a passo completo (provisionamento, DNS, migrations, CI/CD, troubleshooting)

**Modificados**
- `apps/front/next.config.ts` — `output: "standalone"`
- `infra/docker/Dockerfile.prod` — passa a usar `back-entrypoint` no lugar do `node` direto (migrations automáticas)
- `.github/workflows/ci-cd.yml` — habilita `release-image` (agora builda **back + front** no GHCR) e substitui os jobs Koyeb/Vercel por `deploy-akamai` (SSH → `compose pull && up -d`)
- `.env.prod.example` — variáveis da Akamai (domínios, Caddy, Postgres, GHCR)
- `README.md` — seção de deploy de produção

## CI/CD

A cada `push` em `main`: `lint/test/build` → `release-image` (publica as 2 imagens no GHCR) → `deploy-akamai` (SSH na VM faz `pull` e `up -d` com a tag do commit).

## Secrets necessários (GitHub Actions)

- `AKAMAI_HOST`, `AKAMAI_USER`, `AKAMAI_SSH_KEY`
- `NEXT_PUBLIC_API_URL`
- `GHCR_PULL_TOKEN` (opcional, só se as imagens GHCR forem privadas)

## Verificação

- YAML do `ci-cd.yml` e do `docker-compose.prod.yml` válidos
- `docker compose -f infra/docker/docker-compose.prod.yml config` interpola OK com `.env.prod.example`
- Referências cruzadas conferidas (entrypoint, standalone, build-arg, jobs)
- Build Docker completo das imagens não rodado aqui ( PNPM install lento) — recomendado rodar `docker build -f infra/docker/Dockerfile.front.prod .` localmente para confirmar o caminho `apps/front/server.js` do standalone no monorepo

## Observações

- Branch baseada em `developer` (não há mais `render.yaml` para remover, pois o blueprint do Render nunca foi mergeado).
- Não há migrações manuais necessárias — o `back-entrypoint` aplica o `prisma migrate deploy` a cada start do container `api`.