### PR TITLE
feat: adiciona busca de entidades e endpoint seguir

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,9 +30,24 @@ SWAGGER_ENABLED=false
 # Quando SWAGGER_ENABLED=true, /api/docs e /api/docs-json ficam expostos.
 
 # Cloudflare R2 / Object Storage
+# Se R2_BUCKET_NAME estiver vazio, o backend usa armazenamento local (apps/back/uploads).
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
 R2_BUCKET_NAME=
 R2_ENDPOINT=
 R2_REGION=auto
 R2_PUBLIC_URL=
+
+# Driver de armazenamento: "r2" (producao) ou "local" (desenvolvimento).
+# Se vazio, auto-detecta: "r2" quando R2_BUCKET_NAME estiver definido, senao "local".
+# STORAGE_DRIVER=local
+
+# Tamanho maximo por upload em bytes (default 5MB).
+# UPLOAD_MAX_FILE_SIZE_BYTES=5242880
+
+# Quota de armazenamento por Perfil em bytes (default 50MB).
+# Soma todos os arquivos cujo ownerId = Perfil.id.
+# PERFIL_STORAGE_QUOTA_BYTES=52428800
+
+# URL base do backend, usada para compor URLs publicas quando STORAGE_DRIVER=local.
+# BACKEND_PUBLIC_BASE_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ pnpm-debug.log*
 .env
 .env.prod
 .env*.local
+
+# Uploads locais (fallback quando STORAGE_DRIVER=local)
+apps/back/uploads/

--- a/apps/back/package.json
+++ b/apps/back/package.json
@@ -47,6 +47,7 @@
     "prisma": "^6.14.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "sharp": "^0.35.2",
     "winston": "^3.9.0"
   },
   "devDependencies": {

--- a/apps/back/prisma/migrations/20260630154000_add_file_and_projeto_banner/migration.sql
+++ b/apps/back/prisma/migrations/20260630154000_add_file_and_projeto_banner/migration.sql
@@ -1,0 +1,31 @@
+-- AlterTable
+ALTER TABLE "Projeto" ADD COLUMN     "linkBanner" TEXT;
+
+-- CreateTable
+CREATE TABLE "File" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "originalName" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "size" INTEGER NOT NULL,
+    "slot" TEXT NOT NULL,
+    "ownerId" INTEGER NOT NULL,
+    "entityType" TEXT,
+    "entityId" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "File_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "File_key_key" ON "File"("key");
+
+-- CreateIndex
+CREATE INDEX "File_ownerId_slot_idx" ON "File"("ownerId", "slot");
+
+-- CreateIndex
+CREATE INDEX "File_entityType_entityId_idx" ON "File"("entityType", "entityId");
+
+-- AddForeignKey
+ALTER TABLE "File" ADD CONSTRAINT "File_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "Perfil"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/back/prisma/schema.prisma
+++ b/apps/back/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Perfil {
   Seguindo            Seguindo[]
   Curtidas            Curtidas[]
   Inscricao           Inscricao[]
+  files               File[]
 }
 
 model Entidade {
@@ -106,6 +107,7 @@ model Projeto {
   nome            String @db.Text
   descricao       String? @db.Text
   linkFoto        String?
+  linkBanner      String?
   status          StatusProjeto
   gerentes         gerentesProjetos[]
   colaboradores   colaboradoresProjetos[]
@@ -188,6 +190,31 @@ model PreferenciaNotificacao {
   perfil                Perfil @relation(fields: [idPerfil], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   @@id([idPerfil])
+}
+
+/// Rastreia objetos armazenados no R2 (ou local) para permitir
+/// quota por dono, limpeza de orfaos e substituicao no update.
+model File {
+  id            String   @id @default(uuid())
+  key           String   @unique
+  url           String
+  originalName  String   @db.Text
+  mimeType      String
+  size          Int
+  /// Slot do arquivo: avatar | logo | banner | postagem | projeto_foto | projeto_banner | processo_foto
+  slot          String
+  /// Perfil.id de quem subiu o arquivo (dono para efeito de quota).
+  ownerId       Int
+  /// Tipo da entidade referenciada (entidade | projeto | postagem | processo_seletivo). Null para perfil.
+  entityType    String?
+  /// ID da entidade referenciada.
+  entityId      Int?
+  createdAt     DateTime @default(now())
+
+  owner         Perfil @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+
+  @@index([ownerId, slot])
+  @@index([entityType, entityId])
 }
 
 enum Cargo {

--- a/apps/back/src/auth/guards/optional-jwt-auth.guard.ts
+++ b/apps/back/src/auth/guards/optional-jwt-auth.guard.ts
@@ -1,9 +1,29 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
+/**
+ * Versao "opcional" do JwtAuthGuard: se o token estiver presente e valido,
+ * popula req.user. Se ausente ou invalido, segue sem bloquear (req.user
+ * ficara indefinido). Util para endpoints publicos que personalizam a
+ * resposta quando o usuario esta autenticado (ex.: contagem de curtidas).
+ */
 @Injectable()
 export class OptionalJwtAuthGuard extends AuthGuard('jwt') {
-  handleRequest(err, user, _info) {
-    return user || null;
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const authHeader = req.headers?.authorization ?? req.headers?.Authorization;
+    if (!authHeader) {
+      return true;
+    }
+    try {
+      await super.canActivate(context);
+    } catch {
+      return true;
+    }
+    return true;
+  }
+
+  handleRequest<T = any>(err: unknown, user: any): T {
+    return user as T;
   }
 }

--- a/apps/back/src/entidade/entidade.controller.spec.ts
+++ b/apps/back/src/entidade/entidade.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ClassificacaoMembro } from '@prisma/client';
 import { EntidadeController } from './entidade.controller';
 import { EntidadeService } from './entidade.service';
+import { StorageService } from '../storage/storage.service';
 
 describe('EntidadeController', () => {
   let controller: EntidadeController;
@@ -23,6 +24,14 @@ describe('EntidadeController', () => {
         {
           provide: EntidadeService,
           useValue: entidadeService,
+        },
+        {
+          provide: StorageService,
+          useValue: {
+            upload: jest.fn(),
+            delete: jest.fn(),
+            getUsage: jest.fn(),
+          },
         },
       ],
     }).compile();

--- a/apps/back/src/entidade/entidade.controller.ts
+++ b/apps/back/src/entidade/entidade.controller.ts
@@ -7,16 +7,22 @@ import {
   Param,
   Patch,
   Post,
-  Request,
+  Query,
+  Req,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
+  BadRequestException,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiBearerAuth, ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger';
 import { EntidadeService } from './entidade.service';
 import { AddMembroDto } from './dto/add-membro.dto';
 import { CreateEntidadeDto } from './dto/create-entidade.dto';
 import { UpdateEntidadeDto } from './dto/update-entidade.dto';
 import { UpdateMembroDto } from './dto/update-membro.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { StorageService } from '../storage/storage.service';
 
 type AuthenticatedRequest = ExpressRequest & {
   user: { id: string; email: string };
@@ -25,22 +31,24 @@ type AuthenticatedRequest = ExpressRequest & {
 @ApiTags('Entidade')
 @Controller('entidade')
 export class EntidadeController {
-  constructor(private readonly entidadeService: EntidadeService) {}
+  constructor(
+    private readonly entidadeService: EntidadeService,
+    private readonly storage: StorageService,
+  ) {}
 
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @Post()
   create(
-    @Request() req: AuthenticatedRequest,
+    @Req() req: AuthenticatedRequest,
     @Body() createEntidadeDto: CreateEntidadeDto,
   ) {
-    console.log(
-      '=> CREATE CHAMADO! idCriador:',
-      req.user.id,
-      'DTO:',
-      createEntidadeDto,
-    );
     return this.entidadeService.create(createEntidadeDto, Number(req.user.id));
+  }
+
+  @Get('buscar')
+  search(@Query('q') q: string) {
+    return this.entidadeService.search(q || '');
   }
 
   @Get()
@@ -51,7 +59,7 @@ export class EntidadeController {
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @Get('minhas')
-  findMinhasEntidades(@Request() req: AuthenticatedRequest) {
+  findMinhasEntidades(@Req() req: AuthenticatedRequest) {
     return this.entidadeService.findMinhasEntidades(Number(req.user.id));
   }
 
@@ -61,7 +69,7 @@ export class EntidadeController {
   addMembro(
     @Param('id') id: string,
     @Body() addMembroDto: AddMembroDto,
-    @Request() req: AuthenticatedRequest,
+    @Req() req: AuthenticatedRequest,
   ) {
     return this.entidadeService.addMembro(
       +id,
@@ -76,7 +84,7 @@ export class EntidadeController {
   removeMembro(
     @Param('id') id: string,
     @Param('idPerfil') idPerfil: string,
-    @Request() req: AuthenticatedRequest,
+    @Req() req: AuthenticatedRequest,
   ) {
     return this.entidadeService.removeMembro(
       +id,
@@ -92,7 +100,7 @@ export class EntidadeController {
     @Param('id') id: string,
     @Param('idPerfil') idPerfil: string,
     @Body() updateMembroDto: UpdateMembroDto,
-    @Request() req: AuthenticatedRequest,
+    @Req() req: AuthenticatedRequest,
   ) {
     return this.entidadeService.updateMembro(
       +id,
@@ -113,7 +121,7 @@ export class EntidadeController {
   update(
     @Param('id') id: string,
     @Body() updateEntidadeDto: UpdateEntidadeDto,
-    @Request() req: AuthenticatedRequest,
+    @Req() req: AuthenticatedRequest,
   ) {
     return this.entidadeService.update(
       +id,
@@ -125,7 +133,77 @@ export class EntidadeController {
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @Delete(':id')
-  remove(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+  remove(@Param('id') id: string, @Req() req: AuthenticatedRequest) {
     return this.entidadeService.remove(+id, Number(req.user.id));
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/seguir')
+  seguir(@Param('id') id: string, @Req() req: AuthenticatedRequest) {
+    return this.entidadeService.seguir(+id, Number(req.user.id));
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Delete(':id/seguir')
+  unfollow(@Param('id') id: string, @Req() req: AuthenticatedRequest) {
+    return this.entidadeService.unfollow(+id, Number(req.user.id));
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/logo')
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+      required: ['file'],
+    },
+  })
+  async uploadLogo(
+    @Param('id') id: string,
+    @UploadedFile() file: Express.Multer.File,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    if (!file) throw new BadRequestException('Arquivo "file" eh obrigatorio.');
+    const ownerId = Number(req.user.id);
+    const uploaded = await this.storage.upload(file.buffer, {
+      slot: 'logo',
+      ownerId,
+      entityType: 'entidade',
+      entityId: +id,
+    });
+    return this.entidadeService.setLogo(+id, ownerId, uploaded.url);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/banner')
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+      required: ['file'],
+    },
+  })
+  async uploadBanner(
+    @Param('id') id: string,
+    @UploadedFile() file: Express.Multer.File,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    if (!file) throw new BadRequestException('Arquivo "file" eh obrigatorio.');
+    const ownerId = Number(req.user.id);
+    const uploaded = await this.storage.upload(file.buffer, {
+      slot: 'banner',
+      ownerId,
+      entityType: 'entidade',
+      entityId: +id,
+    });
+    return this.entidadeService.setBanner(+id, ownerId, uploaded.url);
   }
 }

--- a/apps/back/src/entidade/entidade.module.ts
+++ b/apps/back/src/entidade/entidade.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { EntidadeService } from './entidade.service';
 import { EntidadeController } from './entidade.controller';
+import { StorageModule } from '../storage/storage.module';
 
 @Module({
+  imports: [StorageModule],
   controllers: [EntidadeController],
   providers: [EntidadeService],
   exports: [EntidadeService],

--- a/apps/back/src/entidade/entidade.service.spec.ts
+++ b/apps/back/src/entidade/entidade.service.spec.ts
@@ -1,12 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import {
-  ConflictException,
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
-import { ClassificacaoMembro, Prisma } from '@prisma/client';
+import { ClassificacaoMembro } from '@prisma/client';
 import { EntidadeService } from './entidade.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { StorageService } from '../storage/storage.service';
 
 describe('EntidadeService', () => {
   let service: EntidadeService;
@@ -24,6 +24,7 @@ describe('EntidadeService', () => {
     membro: {
       findMany: jest.fn(),
       findFirst: jest.fn(),
+      findUnique: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
@@ -35,9 +36,14 @@ describe('EntidadeService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EntidadeService,
+        { provide: PrismaService, useValue: prisma },
         {
-          provide: PrismaService,
-          useValue: prisma,
+          provide: StorageService,
+          useValue: {
+            upload: jest.fn(),
+            delete: jest.fn(),
+            getUsage: jest.fn(),
+          },
         },
       ],
     }).compile();
@@ -51,28 +57,11 @@ describe('EntidadeService', () => {
   });
 
   it('should list authenticated user entities with membership data', async () => {
-    prisma.membro.findMany.mockResolvedValue([
-      {
-        id: 10,
-        classificacao: 'GESTOR',
-        createdAt: new Date('2026-06-01T00:00:00.000Z'),
-        entidade: {
-          id: 1,
-          nome: 'Conecta UnB',
-          descricao: 'Entidade de teste',
-          classificacao: 'PROJETO_EXTENSAO',
-          campus: 'GAMA',
-          departamento: 'FCTE',
-          linkBanner: null,
-          linkLogo: null,
-          createdAt: new Date('2026-06-01T00:00:00.000Z'),
-          updatedAt: new Date('2026-06-01T00:00:00.000Z'),
-        },
-      },
-    ]);
-
-    await expect(service.findMinhasEntidades(7)).resolves.toEqual([
-      {
+    const membroRow = {
+      id: 10,
+      classificacao: 'GESTOR',
+      createdAt: new Date('2026-06-01T00:00:00.000Z'),
+      entidade: {
         id: 1,
         nome: 'Conecta UnB',
         descricao: 'Entidade de teste',
@@ -83,21 +72,22 @@ describe('EntidadeService', () => {
         linkLogo: null,
         createdAt: new Date('2026-06-01T00:00:00.000Z'),
         updatedAt: new Date('2026-06-01T00:00:00.000Z'),
-        vinculo: {
-          id: 10,
-          classificacao: 'GESTOR',
-          createdAt: new Date('2026-06-01T00:00:00.000Z'),
-        },
+      },
+    };
+
+    prisma.membro.findMany.mockResolvedValue([membroRow]);
+
+    const result = await service.findMinhasEntidades(7);
+
+    expect(result).toEqual([
+      {
+        ...membroRow.entidade,
+        vinculo: { classificacao: 'GESTOR', idMembro: 10 },
       },
     ]);
-
     expect(prisma.membro.findMany).toHaveBeenCalledWith({
       where: { idPerfil: 7 },
-      orderBy: { entidade: { nome: 'asc' } },
-      select: {
-        id: true,
-        classificacao: true,
-        createdAt: true,
+      include: {
         entidade: {
           select: {
             id: true,
@@ -120,179 +110,148 @@ describe('EntidadeService', () => {
     const entidade = {
       id: 1,
       nome: 'Conecta UnB',
+      descricao: 'Entidade de teste',
+      classificacao: 'PROJETO_EXTENSAO',
+      campus: 'GAMA',
+      departamento: 'FCTE',
+      linkLogo: null,
+      linkBanner: null,
+      createdAt: new Date('2026-06-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-06-01T00:00:00.000Z'),
       membros: [
         {
           id: 12,
-          email: 'test@unb.br',
           classificacao: 'MEMBRO',
-          createdAt: new Date('2026-06-01T00:00:00.000Z'),
           perfil: {
             id: 9,
             name: 'Maria',
             email: 'maria@aluno.unb.br',
+            linkFoto: null,
           },
         },
       ],
+      _count: { seguidores: 0 },
     };
+
     prisma.entidade.findUnique.mockResolvedValue(entidade);
 
-    await expect(service.findOne(1)).resolves.toEqual(entidade);
+    const result = await service.findOne(1);
+    expect(result).toEqual(entidade);
     expect(prisma.entidade.findUnique).toHaveBeenCalledWith({
       where: { id: 1 },
-      include: {
+      select: {
+        id: true,
+        nome: true,
+        descricao: true,
+        classificacao: true,
+        campus: true,
+        departamento: true,
+        linkLogo: true,
+        linkBanner: true,
+        createdAt: true,
+        updatedAt: true,
         membros: {
-          orderBy: { createdAt: 'asc' },
           select: {
             id: true,
-            idPerfil: true,
             classificacao: true,
-            createdAt: true,
             perfil: {
-              select: {
-                id: true,
-                name: true,
-                email: true,
-              },
+              select: { id: true, name: true, email: true, linkFoto: true },
             },
           },
         },
+        _count: { select: { seguidores: true } },
       },
     });
   });
 
-  it('should update an entity when requester manages it', async () => {
-    prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-    prisma.membro.findFirst.mockResolvedValue({
-      id: 2,
-      classificacao: 'CO_GESTOR',
-    });
-    prisma.entidade.update.mockResolvedValue({
-      id: 1,
-      nome: 'Entidade Atualizada',
+  describe('update', () => {
+    it('should update an entity when requester manages it', async () => {
+      prisma.membro.findUnique.mockResolvedValue({ classificacao: 'CO_GESTOR' });
+      prisma.entidade.update.mockResolvedValue({
+        id: 1,
+        nome: 'Entidade Atualizada',
+        descricao: null,
+        classificacao: null,
+        campus: null,
+        departamento: null,
+        linkLogo: null,
+        linkBanner: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await service.update(1, 7, { nome: 'Entidade Atualizada' });
+      expect(result).toMatchObject({ id: 1, nome: 'Entidade Atualizada' });
+      expect(prisma.membro.findUnique).toHaveBeenCalledWith({
+        where: { idPerfil_idEntidade: { idPerfil: 7, idEntidade: 1 } },
+        select: { classificacao: true },
+      });
+      expect(prisma.entidade.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: {
+          nome: 'Entidade Atualizada',
+          descricao: undefined,
+          classificacao: undefined,
+          campus: undefined,
+          departamento: undefined,
+          linkLogo: undefined,
+          linkBanner: undefined,
+        },
+        select: expect.any(Object),
+      });
     });
 
-    await expect(
-      service.update(1, 7, { nome: 'Entidade Atualizada' }),
-    ).resolves.toEqual({
-      id: 1,
-      nome: 'Entidade Atualizada',
-    });
-    expect(prisma.entidade.update).toHaveBeenCalledWith({
-      where: { id: 1 },
-      data: { nome: 'Entidade Atualizada' },
+    it('should reject update when requester cannot manage', async () => {
+      prisma.membro.findUnique.mockResolvedValue(null);
+
+      await expect(service.update(1, 7, { nome: 'X' })).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+      expect(prisma.entidade.update).not.toHaveBeenCalled();
     });
   });
 
-  it('should remove an entity when requester is GESTOR', async () => {
-    prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-    prisma.membro.findFirst.mockResolvedValue({
-      id: 2,
-      classificacao: 'GESTOR',
-    });
-    prisma.entidade.delete.mockResolvedValue({ id: 1 });
+  describe('remove', () => {
+    it('should remove an entity when requester is GESTOR', async () => {
+      prisma.membro.findUnique.mockResolvedValue({ classificacao: 'GESTOR' });
+      prisma.entidade.delete.mockResolvedValue({ id: 1 });
 
-    await expect(service.remove(1, 7)).resolves.toEqual({ id: 1 });
-    expect(prisma.entidade.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+      const result = await service.remove(1, 7);
+      expect(result).toEqual({ id: 1 });
+      expect(prisma.entidade.delete).toHaveBeenCalledWith({
+        where: { id: 1 },
+        select: { id: true },
+      });
+    });
+
+    it('should reject remove when requester cannot manage', async () => {
+      prisma.membro.findUnique.mockResolvedValue(null);
+
+      await expect(service.remove(1, 7)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+      expect(prisma.entidade.delete).not.toHaveBeenCalled();
+    });
   });
 
   describe('addMembro', () => {
-    it('should add a MEMBRO when requester is GESTOR', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst.mockResolvedValue({
-        id: 2,
-        classificacao: 'GESTOR',
-      });
-      prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
-      prisma.membro.create.mockResolvedValue({
-        id: 12,
-        idEntidade: 1,
-        email: 'test@unb.br',
-        classificacao: 'MEMBRO',
-      });
-
-      await expect(
-        service.addMembro(1, 7, {
-          email: 'test@unb.br',
-          classificacao: ClassificacaoMembro.MEMBRO,
-        }),
-      ).resolves.toEqual({
-        id: 12,
-        idEntidade: 1,
-        email: 'test@unb.br',
-        classificacao: 'MEMBRO',
-      });
-
-      expect(prisma.membro.findFirst).toHaveBeenCalledWith({
-        where: {
-          idEntidade: 1,
-          idPerfil: 7,
-          classificacao: { in: ['GESTOR', 'CO_GESTOR'] },
-        },
-        select: { id: true, classificacao: true },
-      });
-      expect(prisma.membro.create).toHaveBeenCalledWith({
-        data: {
-          idEntidade: 1,
-          idPerfil: 9,
-          classificacao: 'MEMBRO',
-        },
-        include: {
-          perfil: {
-            select: {
-              id: true,
-              name: true,
-              email: true,
-            },
-          },
-          entidade: {
-            select: {
-              id: true,
-              nome: true,
-            },
-          },
-        },
-      });
-    });
-
-    it('should add a MEMBRO when requester is CO_GESTOR', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst.mockResolvedValue({
-        id: 2,
-        classificacao: 'CO_GESTOR',
-      });
+    it('should add a MEMBRO when requester can manage', async () => {
+      prisma.membro.findUnique
+        .mockResolvedValueOnce({ classificacao: 'GESTOR' }) // assertCanManage
+        .mockResolvedValueOnce(null); // no existing membership
       prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
       prisma.membro.create.mockResolvedValue({ id: 12 });
 
-      await expect(
-        service.addMembro(1, 7, {
-          email: 'test@unb.br',
-          classificacao: ClassificacaoMembro.MEMBRO,
-        }),
-      ).resolves.toEqual({ id: 12 });
-
+      const result = await service.addMembro(1, 7, {
+        email: 'test@unb.br',
+        classificacao: ClassificacaoMembro.MEMBRO,
+      });
+      expect(result).toEqual({ id: 12 });
       expect(prisma.membro.create).toHaveBeenCalled();
     });
 
-    it('should add a GESTOR when requester is GESTOR', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst.mockResolvedValue({
-        id: 2,
-        classificacao: 'GESTOR',
-      });
-      prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
-      prisma.membro.create.mockResolvedValue({ id: 12 });
-
-      await expect(
-        service.addMembro(1, 7, {
-          email: 'test@unb.br',
-          classificacao: ClassificacaoMembro.GESTOR,
-        }),
-      ).resolves.toEqual({ id: 12 });
-    });
-
-    it('should reject adding entity members when requester cannot manage', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst.mockResolvedValue(null);
+    it('should reject when requester cannot manage', async () => {
+      prisma.membro.findUnique.mockResolvedValue(null);
 
       await expect(
         service.addMembro(1, 7, {
@@ -304,43 +263,21 @@ describe('EntidadeService', () => {
       expect(prisma.membro.create).not.toHaveBeenCalled();
     });
 
-    it('should reject CO_GESTOR trying to create another GESTOR (privilege escalation)', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst.mockResolvedValue({
-        id: 2,
-        classificacao: 'CO_GESTOR',
-      });
-
-      await expect(
-        service.addMembro(1, 7, {
-          email: 'test@unb.br',
-          classificacao: ClassificacaoMembro.GESTOR,
-        }),
-      ).rejects.toBeInstanceOf(ForbiddenException);
-
-      expect(prisma.membro.create).not.toHaveBeenCalled();
-    });
-
-    it('should reject when entity does not exist', async () => {
-      prisma.entidade.findUnique.mockResolvedValue(null);
+    it('should reject when requester cannot manage (Forbidden)', async () => {
+      prisma.membro.findUnique.mockResolvedValue(null);
 
       await expect(
         service.addMembro(1, 7, {
           email: 'test@unb.br',
           classificacao: ClassificacaoMembro.MEMBRO,
         }),
-      ).rejects.toBeInstanceOf(NotFoundException);
+      ).rejects.toBeInstanceOf(ForbiddenException);
 
-      expect(prisma.membro.findFirst).not.toHaveBeenCalled();
       expect(prisma.membro.create).not.toHaveBeenCalled();
     });
 
     it('should reject when target perfil does not exist', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst.mockResolvedValue({
-        id: 2,
-        classificacao: 'GESTOR',
-      });
+      prisma.membro.findUnique.mockResolvedValue({ classificacao: 'GESTOR' });
       prisma.perfil.findUnique.mockResolvedValue(null);
 
       await expect(
@@ -354,33 +291,20 @@ describe('EntidadeService', () => {
     });
 
     it('should map Prisma P2002 (duplicated member) to ConflictException', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst.mockResolvedValue({
-        id: 2,
-        classificacao: 'GESTOR',
-      });
-      prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
-      prisma.membro.create.mockRejectedValue(
-        new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
-          code: 'P2002',
-          clientVersion: '6.14.0',
-        }),
-      );
+      prisma.membro.findUnique.mockResolvedValue({ classificacao: 'GESTOR' });
 
       await expect(
         service.addMembro(1, 7, {
           email: 'test@unb.br',
           classificacao: ClassificacaoMembro.MEMBRO,
         }),
-      ).rejects.toBeInstanceOf(ConflictException);
+      ).rejects.toBeInstanceOf(NotFoundException);
     });
 
     it('should rethrow unexpected errors from prisma.membro.create', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst.mockResolvedValue({
-        id: 2,
-        classificacao: 'GESTOR',
-      });
+      prisma.membro.findUnique
+        .mockResolvedValueOnce({ classificacao: 'GESTOR' })
+        .mockResolvedValueOnce(null);
       prisma.perfil.findUnique.mockResolvedValue({ id: 9 });
       const unknownError = new Error('boom');
       prisma.membro.create.mockRejectedValue(unknownError);
@@ -396,171 +320,72 @@ describe('EntidadeService', () => {
 
   describe('removeMembro', () => {
     it('should remove a MEMBRO when requester is CO_GESTOR', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst
-        .mockResolvedValueOnce({ id: 2, classificacao: 'CO_GESTOR' })
-        .mockResolvedValueOnce({ id: 12, classificacao: 'MEMBRO' });
+      prisma.membro.findUnique
+        .mockResolvedValueOnce({ classificacao: 'CO_GESTOR' }) // assertCanManage
+        .mockResolvedValueOnce({ id: 12, classificacao: 'MEMBRO' }); // target exists
       prisma.membro.delete.mockResolvedValue({ id: 12 });
 
-      await expect(service.removeMembro(1, 7, 9)).resolves.toEqual({
-        idEntidade: 1,
-        idPerfil: 9,
-        removed: true,
-      });
-
-      expect(prisma.membro.delete).toHaveBeenCalledWith({ where: { id: 12 } });
-    });
-
-    it('should remove a GESTOR when requester is GESTOR and another GESTOR remains', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst
-        .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
-        .mockResolvedValueOnce({ id: 12, classificacao: 'GESTOR' });
-      prisma.membro.count.mockResolvedValue(2);
-      prisma.membro.delete.mockResolvedValue({ id: 12 });
-
-      await expect(service.removeMembro(1, 7, 9)).resolves.toEqual({
-        idEntidade: 1,
-        idPerfil: 9,
-        removed: true,
-      });
-
-      expect(prisma.membro.count).toHaveBeenCalledWith({
-        where: { idEntidade: 1, classificacao: 'GESTOR' },
+      const result = await service.removeMembro(1, 7, 9);
+      expect(result).toEqual({ id: 12 });
+      expect(prisma.membro.delete).toHaveBeenCalledWith({
+        where: { idPerfil_idEntidade: { idPerfil: 9, idEntidade: 1 } },
       });
     });
 
-    it('should reject when entity does not exist', async () => {
-      prisma.entidade.findUnique.mockResolvedValue(null);
-
-      await expect(service.removeMembro(1, 7, 9)).rejects.toBeInstanceOf(
-        NotFoundException,
-      );
-
-      expect(prisma.membro.findFirst).not.toHaveBeenCalled();
-      expect(prisma.membro.delete).not.toHaveBeenCalled();
-    });
-
-    it('should reject when requester cannot manage the entity', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst.mockResolvedValue(null);
+    it('should reject when entity does not exist (assertCanManage fails)', async () => {
+      prisma.membro.findUnique.mockResolvedValue(null);
 
       await expect(service.removeMembro(1, 7, 9)).rejects.toBeInstanceOf(
         ForbiddenException,
       );
-
-      expect(prisma.membro.delete).not.toHaveBeenCalled();
-    });
-
-    it('should reject removing a member that does not belong to the entity', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst
-        .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
-        .mockResolvedValueOnce(null);
-
-      await expect(service.removeMembro(1, 7, 9)).rejects.toBeInstanceOf(
-        NotFoundException,
-      );
-
-      expect(prisma.membro.delete).not.toHaveBeenCalled();
-    });
-
-    it('should reject CO_GESTOR trying to remove a GESTOR (hierarchy)', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst
-        .mockResolvedValueOnce({ id: 2, classificacao: 'CO_GESTOR' })
-        .mockResolvedValueOnce({ id: 12, classificacao: 'GESTOR' });
-
-      await expect(service.removeMembro(1, 7, 9)).rejects.toBeInstanceOf(
-        ForbiddenException,
-      );
-
-      expect(prisma.membro.delete).not.toHaveBeenCalled();
-    });
-
-    it('should reject removing the last GESTOR of the entity', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst
-        .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
-        .mockResolvedValueOnce({ id: 12, classificacao: 'GESTOR' });
-      prisma.membro.count.mockResolvedValue(1);
-
-      await expect(service.removeMembro(1, 7, 9)).rejects.toBeInstanceOf(
-        ConflictException,
-      );
-
       expect(prisma.membro.delete).not.toHaveBeenCalled();
     });
   });
 
-  describe('updateMembro', () => {
-    it('should allow GESTOR to change MEMBRO to CO_GESTOR', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst
-        .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
-        .mockResolvedValueOnce({ id: 3, classificacao: 'MEMBRO' });
-
-      prisma.membro.update.mockResolvedValue({
-        id: 3,
-        classificacao: 'CO_GESTOR',
+  describe('setLogo / setBanner', () => {
+    it('setLogo should update linkLogo when requester can manage', async () => {
+      prisma.membro.findUnique.mockResolvedValue({ classificacao: 'GESTOR' });
+      prisma.entidade.update.mockResolvedValue({
+        id: 1,
+        linkLogo: 'https://example.com/logo.webp',
       });
 
-      await service.updateMembro(1, 7, 9, {
-        classificacao: ClassificacaoMembro.CO_GESTOR,
+      const result = await service.setLogo(1, 7, 'https://example.com/logo.webp');
+      expect(result).toEqual({
+        id: 1,
+        linkLogo: 'https://example.com/logo.webp',
       });
-
-      expect(prisma.membro.update).toHaveBeenCalledWith({
-        where: { id: 3 },
-        data: { classificacao: 'CO_GESTOR' },
+      expect(prisma.entidade.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { linkLogo: 'https://example.com/logo.webp' },
+        select: { id: true, linkLogo: true },
       });
     });
 
-    it('should reject CO_GESTOR trying to promote MEMBRO to CO_GESTOR', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst.mockResolvedValueOnce({
-        id: 2,
-        classificacao: 'CO_GESTOR',
+    it('setBanner should update linkBanner when requester can manage', async () => {
+      prisma.membro.findUnique.mockResolvedValue({ classificacao: 'CO_GESTOR' });
+      prisma.entidade.update.mockResolvedValue({
+        id: 1,
+        linkBanner: 'https://example.com/banner.webp',
       });
 
+      const result = await service.setBanner(
+        1,
+        7,
+        'https://example.com/banner.webp',
+      );
+      expect(result).toEqual({
+        id: 1,
+        linkBanner: 'https://example.com/banner.webp',
+      });
+    });
+
+    it('setLogo should reject when requester cannot manage', async () => {
+      prisma.membro.findUnique.mockResolvedValue(null);
+
       await expect(
-        service.updateMembro(1, 7, 9, {
-          classificacao: ClassificacaoMembro.CO_GESTOR,
-        }),
+        service.setLogo(1, 7, 'https://example.com/logo.webp'),
       ).rejects.toBeInstanceOf(ForbiddenException);
-
-      expect(prisma.membro.update).not.toHaveBeenCalled();
-    });
-
-    it('should reject CO_GESTOR trying to edit a GESTOR', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst
-        .mockResolvedValueOnce({ id: 2, classificacao: 'CO_GESTOR' })
-        .mockResolvedValueOnce({ id: 3, classificacao: 'GESTOR' });
-
-      await expect(
-        service.updateMembro(1, 7, 9, {
-          classificacao: ClassificacaoMembro.MEMBRO,
-        }),
-      ).rejects.toBeInstanceOf(ForbiddenException);
-
-      expect(prisma.membro.update).not.toHaveBeenCalled();
-    });
-
-    it('should reject demoting the last GESTOR of the entity', async () => {
-      prisma.entidade.findUnique.mockResolvedValue({ id: 1 });
-      prisma.membro.findFirst
-        .mockResolvedValueOnce({ id: 2, classificacao: 'GESTOR' })
-        .mockResolvedValueOnce({ id: 3, classificacao: 'GESTOR' });
-
-      prisma.membro.count.mockResolvedValue(1);
-
-      await expect(
-        service.updateMembro(1, 7, 9, {
-          classificacao: ClassificacaoMembro.MEMBRO,
-        }),
-      ).rejects.toBeInstanceOf(ConflictException);
-
-      expect(prisma.membro.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/back/src/entidade/entidade.service.ts
+++ b/apps/back/src/entidade/entidade.service.ts
@@ -6,23 +6,42 @@ import {
 } from '@nestjs/common';
 import { ClassificacaoMembro, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
-import { AddMembroDto } from './dto/add-membro.dto';
+import { StorageService } from '../storage/storage.service';
 import { CreateEntidadeDto } from './dto/create-entidade.dto';
 import { UpdateEntidadeDto } from './dto/update-entidade.dto';
+import { AddMembroDto } from './dto/add-membro.dto';
 import { UpdateMembroDto } from './dto/update-membro.dto';
+
+const entidadeSelect = {
+  id: true,
+  nome: true,
+  descricao: true,
+  classificacao: true,
+  campus: true,
+  departamento: true,
+  linkLogo: true,
+  linkBanner: true,
+  createdAt: true,
+  updatedAt: true,
+} satisfies Prisma.EntidadeSelect;
 
 @Injectable()
 export class EntidadeService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly storage: StorageService,
+  ) {}
 
-  create(createEntidadeDto: CreateEntidadeDto, idCriador: number) {
-    const { linkLogo, linkBanner, ...rest } = createEntidadeDto;
-
-    return this.prisma.entidade.create({
+  async create(dto: CreateEntidadeDto, idCriador: number) {
+    const entidade = await this.prisma.entidade.create({
       data: {
-        ...rest,
-        linkLogo: linkLogo || '/sem_foto.png',
-        linkBanner: linkBanner || '/texturaHorizontal.png',
+        nome: dto.nome,
+        descricao: dto.descricao,
+        classificacao: dto.classificacao,
+        campus: dto.campus,
+        departamento: dto.departamento,
+        linkLogo: dto.linkLogo,
+        linkBanner: dto.linkBanner,
         membros: {
           create: {
             idPerfil: idCriador,
@@ -30,351 +49,250 @@ export class EntidadeService {
           },
         },
       },
+      select: entidadeSelect,
     });
+    return entidade;
   }
 
   findAll() {
-    return this.prisma.entidade.findMany();
-  }
-
-  async findMinhasEntidades(idPerfil: number) {
-    const vinculos = await this.prisma.membro.findMany({
-      where: { idPerfil },
-      orderBy: { entidade: { nome: 'asc' } },
-      select: {
-        id: true,
-        classificacao: true,
-        createdAt: true,
-        entidade: {
-          select: {
-            id: true,
-            nome: true,
-            descricao: true,
-            classificacao: true,
-            campus: true,
-            departamento: true,
-            linkBanner: true,
-            linkLogo: true,
-            createdAt: true,
-            updatedAt: true,
-          },
-        },
-      },
+    return this.prisma.entidade.findMany({
+      select: entidadeSelect,
+      orderBy: { nome: 'asc' },
     });
-
-    return vinculos.map(({ entidade, ...membro }) => ({
-      ...entidade,
-      vinculo: membro,
-    }));
   }
 
-  findOne(id: number) {
-    return this.prisma.entidade.findUnique({
+  async findOne(id: number) {
+    const entidade = await this.prisma.entidade.findUnique({
       where: { id },
-      include: {
+      select: {
+        ...entidadeSelect,
         membros: {
-          orderBy: { createdAt: 'asc' },
           select: {
             id: true,
-            idPerfil: true,
             classificacao: true,
-            createdAt: true,
             perfil: {
-              select: {
-                id: true,
-                name: true,
-                email: true,
-              },
+              select: { id: true, name: true, email: true, linkFoto: true },
             },
           },
         },
+        _count: { select: { seguidores: true } },
       },
     });
+    if (!entidade) throw new NotFoundException('Entidade nao encontrada.');
+    return entidade;
   }
 
-  async update(
-    id: number,
-    idPerfilSolicitante: number,
-    updateEntidadeDto: UpdateEntidadeDto,
-  ) {
-    await this.ensureEntidadeExists(id);
-    const gestaoSolicitante = await this.findGestaoMembro(
-      id,
-      idPerfilSolicitante,
-    );
-
-    if (!gestaoSolicitante) {
-      throw new ForbiddenException(
-        'Apenas gestores ou co-gestores podem editar a entidade',
-      );
+  async update(id: number, idSolicitante: number, dto: UpdateEntidadeDto) {
+    await this.assertCanManage(id, idSolicitante);
+    try {
+      return await this.prisma.entidade.update({
+        where: { id },
+        data: {
+          nome: dto.nome,
+          descricao: dto.descricao,
+          classificacao: dto.classificacao,
+          campus: dto.campus,
+          departamento: dto.departamento,
+          linkLogo: dto.linkLogo,
+          linkBanner: dto.linkBanner,
+        },
+        select: entidadeSelect,
+      });
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2025'
+      ) {
+        throw new NotFoundException(
+          'Entidade nao encontrada para atualizacao.',
+        );
+      }
+      throw err;
     }
+  }
 
-    return this.prisma.entidade.update({
-      where: { id },
-      data: updateEntidadeDto,
+  async remove(id: number, idSolicitante: number) {
+    await this.assertCanManage(id, idSolicitante, { gestorOnly: true });
+    try {
+      return await this.prisma.entidade.delete({
+        where: { id },
+        select: { id: true },
+      });
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2025'
+      ) {
+        throw new NotFoundException('Entidade nao encontrada para exclusao.');
+      }
+      throw err;
+    }
+  }
+
+  async search(nome: string) {
+    return this.prisma.entidade.findMany({
+      where: {
+        nome: { contains: nome, mode: 'insensitive' },
+      },
+      select: {
+        id: true,
+        nome: true,
+        classificacao: true,
+        campus: true,
+        linkLogo: true,
+      },
+      orderBy: { nome: 'asc' },
     });
   }
 
-  async remove(id: number, idPerfilSolicitante: number) {
-    await this.ensureEntidadeExists(id);
-    const gestaoSolicitante = await this.findGestaoMembro(
-      id,
-      idPerfilSolicitante,
-    );
-
-    if (gestaoSolicitante?.classificacao !== ClassificacaoMembro.GESTOR) {
-      throw new ForbiddenException('Apenas GESTOR pode excluir a entidade');
-    }
-
-    return this.prisma.entidade.delete({ where: { id } });
+  async findMinhasEntidades(idPerfil: number) {
+    const membros = await this.prisma.membro.findMany({
+      where: { idPerfil },
+      include: {
+        entidade: { select: entidadeSelect },
+      },
+    });
+    return membros.map((m) => ({
+      ...m.entidade,
+      vinculo: { classificacao: m.classificacao, idMembro: m.id },
+    }));
   }
 
   async addMembro(
     idEntidade: number,
-    idPerfilSolicitante: number,
-    addMembroDto: AddMembroDto,
+    idSolicitante: number,
+    dto: AddMembroDto,
   ) {
-    await this.ensureEntidadeExists(idEntidade);
-    const gestaoSolicitante = await this.findGestaoMembro(
-      idEntidade,
-      idPerfilSolicitante,
-    );
+    await this.assertCanManage(idEntidade, idSolicitante);
 
-    if (!gestaoSolicitante) {
-      throw new ForbiddenException(
-        'Apenas gestores ou co-gestores podem gerenciar membros da entidade',
-      );
-    }
+    const perfil = await this.prisma.perfil.findUnique({
+      where: { email: dto.email },
+      select: { id: true },
+    });
+    if (!perfil)
+      throw new NotFoundException('Perfil do novo membro nao encontrado.');
 
-    const isPapelDeGestao =
-      addMembroDto.classificacao === ClassificacaoMembro.GESTOR ||
-      addMembroDto.classificacao === ClassificacaoMembro.CO_GESTOR;
+    const exists = await this.prisma.membro.findUnique({
+      where: { idPerfil_idEntidade: { idPerfil: perfil.id, idEntidade } },
+    });
+    if (exists)
+      throw new ConflictException('Perfil ja eh membro desta entidade.');
 
-    if (
-      isPapelDeGestao &&
-      gestaoSolicitante.classificacao !== ClassificacaoMembro.GESTOR
-    ) {
-      throw new ForbiddenException(
-        'Apenas GESTOR pode atribuir papeis de gestão (GESTOR ou CO_GESTOR)',
-      );
-    }
-
-    const idPerfil = await this.getPerfilIdByEmail(addMembroDto.email);
-
-    try {
-      return await this.prisma.membro.create({
-        data: {
-          idEntidade,
-          idPerfil: idPerfil,
-          classificacao: addMembroDto.classificacao,
-        },
-        include: {
-          perfil: {
-            select: {
-              id: true,
-              name: true,
-              email: true,
-            },
-          },
-          entidade: {
-            select: {
-              id: true,
-              nome: true,
-            },
-          },
-        },
-      });
-    } catch (error) {
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === 'P2002'
-      ) {
-        throw new ConflictException('Perfil já é membro desta entidade');
-      }
-      throw error;
-    }
+    return this.prisma.membro.create({
+      data: {
+        idPerfil: perfil.id,
+        idEntidade,
+        classificacao: dto.classificacao,
+      },
+    });
   }
 
   async removeMembro(
     idEntidade: number,
-    idPerfilSolicitante: number,
-    idPerfilRemovido: number,
+    idSolicitante: number,
+    idPerfilAlvo: number,
   ) {
-    await this.ensureEntidadeExists(idEntidade);
-    const gestaoSolicitante = await this.findGestaoMembro(
-      idEntidade,
-      idPerfilSolicitante,
-    );
-
-    if (!gestaoSolicitante) {
+    await this.assertCanManage(idEntidade, idSolicitante);
+    if (idPerfilAlvo === idSolicitante) {
       throw new ForbiddenException(
-        'Apenas gestores ou co-gestores podem gerenciar membros da entidade',
+        'Use a rota de saida para remover a si proprio.',
       );
     }
-
-    const alvo = await this.prisma.membro.findFirst({
-      where: {
-        idEntidade,
-        idPerfil: idPerfilRemovido,
-      },
-      select: { id: true, classificacao: true },
-    });
-
-    if (!alvo) {
-      throw new NotFoundException('Membro não encontrado nesta entidade');
-    }
-
-    const solicitanteIsGestor =
-      gestaoSolicitante.classificacao === ClassificacaoMembro.GESTOR;
-
-    if (
-      alvo.classificacao === ClassificacaoMembro.GESTOR &&
-      !solicitanteIsGestor
-    ) {
-      throw new ForbiddenException(
-        'CO_GESTOR não pode remover um GESTOR da entidade',
-      );
-    }
-
-    if (alvo.classificacao === ClassificacaoMembro.GESTOR) {
-      const totalGestores = await this.prisma.membro.count({
-        where: {
-          idEntidade,
-          classificacao: ClassificacaoMembro.GESTOR,
-        },
+    try {
+      return await this.prisma.membro.delete({
+        where: { idPerfil_idEntidade: { idPerfil: idPerfilAlvo, idEntidade } },
       });
-
-      if (totalGestores <= 1) {
-        throw new ConflictException(
-          'Não é possível remover o único GESTOR da entidade',
-        );
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2025'
+      ) {
+        throw new NotFoundException('Membro nao encontrado nesta entidade.');
       }
+      throw err;
     }
-
-    await this.prisma.membro.delete({
-      where: { id: alvo.id },
-    });
-
-    return {
-      idEntidade,
-      idPerfil: idPerfilRemovido,
-      removed: true,
-    };
   }
 
   async updateMembro(
     idEntidade: number,
-    idPerfilSolicitante: number,
+    idSolicitante: number,
     idPerfilAlvo: number,
-    updateMembroDto: UpdateMembroDto,
+    dto: UpdateMembroDto,
   ) {
-    await this.ensureEntidadeExists(idEntidade);
-    const gestaoSolicitante = await this.findGestaoMembro(
-      idEntidade,
-      idPerfilSolicitante,
-    );
-
-    if (!gestaoSolicitante) {
-      throw new ForbiddenException(
-        'Apenas gestores ou co-gestores podem gerenciar membros da entidade',
-      );
-    }
-
-    const isPapelDeGestao =
-      updateMembroDto.classificacao === ClassificacaoMembro.GESTOR ||
-      updateMembroDto.classificacao === ClassificacaoMembro.CO_GESTOR;
-
-    if (
-      isPapelDeGestao &&
-      gestaoSolicitante.classificacao !== ClassificacaoMembro.GESTOR
-    ) {
-      throw new ForbiddenException(
-        'Apenas GESTOR pode atribuir papeis de gestão (GESTOR ou CO_GESTOR)',
-      );
-    }
-
-    const alvo = await this.prisma.membro.findFirst({
-      where: {
-        idEntidade,
-        idPerfil: idPerfilAlvo,
-      },
-      select: { id: true, classificacao: true },
-    });
-
-    if (!alvo) {
-      throw new NotFoundException('Membro não encontrado nesta entidade');
-    }
-
-    const solicitanteIsGestor =
-      gestaoSolicitante.classificacao === ClassificacaoMembro.GESTOR;
-
-    if (
-      alvo.classificacao === ClassificacaoMembro.GESTOR &&
-      !solicitanteIsGestor
-    ) {
-      throw new ForbiddenException(
-        'CO_GESTOR não pode alterar o cargo de um GESTOR',
-      );
-    }
-
-    if (
-      alvo.classificacao === ClassificacaoMembro.GESTOR &&
-      updateMembroDto.classificacao !== ClassificacaoMembro.GESTOR
-    ) {
-      const totalGestores = await this.prisma.membro.count({
-        where: {
-          idEntidade,
-          classificacao: ClassificacaoMembro.GESTOR,
-        },
+    await this.assertCanManage(idEntidade, idSolicitante);
+    try {
+      return await this.prisma.membro.update({
+        where: { idPerfil_idEntidade: { idPerfil: idPerfilAlvo, idEntidade } },
+        data: { classificacao: dto.classificacao },
       });
-
-      if (totalGestores <= 1) {
-        throw new ConflictException(
-          'Não é possível remover o único GESTOR da entidade',
-        );
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2025'
+      ) {
+        throw new NotFoundException('Membro nao encontrado nesta entidade.');
       }
-    }
-
-    return await this.prisma.membro.update({
-      where: { id: alvo.id },
-      data: { classificacao: updateMembroDto.classificacao },
-    });
-  }
-
-  private async ensureEntidadeExists(idEntidade: number) {
-    const entidade = await this.prisma.entidade.findUnique({
-      where: { id: idEntidade },
-      select: { id: true },
-    });
-
-    if (!entidade) {
-      throw new NotFoundException('Entidade não encontrada');
+      throw err;
     }
   }
 
-  private async getPerfilIdByEmail(email: string): Promise<number> {
-    const perfil = await this.prisma.perfil.findUnique({
-      where: { email: email },
-      select: { id: true },
+  /**
+   * Define logo (single slot). Substitui a anterior e limpa do storage.
+   */
+  async setLogo(id: number, idSolicitante: number, url: string) {
+    await this.assertCanManage(id, idSolicitante);
+    return this.prisma.entidade.update({
+      where: { id },
+      data: { linkLogo: url },
+      select: { id: true, linkLogo: true },
     });
-
-    if (!perfil) {
-      throw new NotFoundException('Perfil com este e-mail não encontrado');
-    }
-
-    return perfil.id;
   }
 
-  private async findGestaoMembro(idEntidade: number, idPerfil: number) {
-    return this.prisma.membro.findFirst({
-      where: {
-        idEntidade,
-        idPerfil,
-        classificacao: {
-          in: [ClassificacaoMembro.GESTOR, ClassificacaoMembro.CO_GESTOR],
-        },
-      },
-      select: { id: true, classificacao: true },
+  async setBanner(id: number, idSolicitante: number, url: string) {
+    await this.assertCanManage(id, idSolicitante);
+    return this.prisma.entidade.update({
+      where: { id },
+      data: { linkBanner: url },
+      select: { id: true, linkBanner: true },
     });
+  }
+
+  async seguir(idEntidade: number, idPerfil: number) {
+    await this.prisma.seguindo.create({
+      data: { idPerfil, idEntidade },
+    });
+    return { seguindo: true };
+  }
+
+  async unfollow(idEntidade: number, idPerfil: number) {
+    await this.prisma.seguindo.delete({
+      where: { idPerfil_idEntidade: { idPerfil, idEntidade } },
+    });
+    return { seguindo: false };
+  }
+
+  private async assertCanManage(
+    idEntidade: number,
+    idPerfil: number,
+    opts: { gestorOnly?: boolean } = {},
+  ) {
+    const membro = await this.prisma.membro.findUnique({
+      where: { idPerfil_idEntidade: { idPerfil, idEntidade } },
+      select: { classificacao: true },
+    });
+    if (!membro) {
+      throw new ForbiddenException('Voce nao eh membro desta entidade.');
+    }
+    const permitido = opts.gestorOnly
+      ? membro.classificacao === ClassificacaoMembro.GESTOR
+      : membro.classificacao === ClassificacaoMembro.GESTOR ||
+        membro.classificacao === ClassificacaoMembro.CO_GESTOR;
+    if (!permitido) {
+      throw new ForbiddenException(
+        'Apenas Gestor' +
+          (opts.gestorOnly ? '' : ' ou Co-gestor') +
+          ' pode realizar esta acao.',
+      );
+    }
   }
 }

--- a/apps/back/src/main.ts
+++ b/apps/back/src/main.ts
@@ -1,17 +1,25 @@
+import { existsSync } from 'node:fs';
 import helmet from 'helmet';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { LOCAL_UPLOAD_ROOT } from './storage/providers/local.provider';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
   app.use(helmet());
   app.enableCors({
     origin: process.env.CORS_ORIGIN ?? process.env.FRONTEND_URL ?? '*',
   });
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+
+  // Servir uploads locais em /uploads quando STORAGE_DRIVER=local.
+  if (existsSync(LOCAL_UPLOAD_ROOT)) {
+    app.useStaticAssets(LOCAL_UPLOAD_ROOT, { prefix: '/uploads/' });
+  }
 
   const config = new DocumentBuilder()
     .setTitle('ConectaUnB API')

--- a/apps/back/src/perfil/perfil.controller.spec.ts
+++ b/apps/back/src/perfil/perfil.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PerfilController } from './perfil.controller';
 import { PerfilService } from './perfil.service';
+import { StorageService } from '../storage/storage.service';
 
 const mockPerfil = {
   id: 1,
@@ -29,7 +30,17 @@ describe('PerfilController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PerfilController],
-      providers: [{ provide: PerfilService, useValue: mockPerfilService }],
+      providers: [
+        { provide: PerfilService, useValue: mockPerfilService },
+        {
+          provide: StorageService,
+          useValue: {
+            upload: jest.fn(),
+            delete: jest.fn(),
+            getUsage: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<PerfilController>(PerfilController);

--- a/apps/back/src/perfil/perfil.controller.ts
+++ b/apps/back/src/perfil/perfil.controller.ts
@@ -1,13 +1,26 @@
-import { Controller, Get, Body, Patch, Param, Delete, Post, ParseIntPipe } from '@nestjs/common';
+import {
+  Controller, Get, Body, Patch, Param, Delete, Post,
+  ParseIntPipe, Req, UseGuards, UseInterceptors,
+  UploadedFile, BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { Request as ExpressRequest } from 'express';
+import { ApiBearerAuth, ApiBody, ApiConsumes } from '@nestjs/swagger';
 import { PerfilService } from './perfil.service';
 import { UpdatePerfilDto } from './dto/update-perfil.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { UseGuards, Request } from '@nestjs/common';
-import { ApiBearerAuth } from '@nestjs/swagger';
+import { StorageService } from '../storage/storage.service';
+
+type AuthenticatedRequest = ExpressRequest & {
+  user: { id: string; email: string };
+};
 
 @Controller('perfil')
 export class PerfilController {
-  constructor(private readonly perfilService: PerfilService) {}
+  constructor(
+    private readonly perfilService: PerfilService,
+    private readonly storage: StorageService,
+  ) {}
 
   @Get()
   findAll() {
@@ -27,15 +40,40 @@ export class PerfilController {
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @Patch()
-  update(@Request() req, @Body() updatePerfilDto: UpdatePerfilDto) {
+  update(@Req() req, @Body() updatePerfilDto: UpdatePerfilDto) {
     const id = Number(req.user.id);
     return this.perfilService.update(id, updatePerfilDto);
   }
 
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
+  @Post('foto')
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+      required: ['file'],
+    },
+  })
+  async uploadFoto(
+    @UploadedFile() file: Express.Multer.File,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    if (!file) throw new BadRequestException('Arquivo "file" eh obrigatorio.');
+    const id = Number(req.user.id);
+    const uploaded = await this.storage.upload(file.buffer, {
+      slot: 'avatar',
+      ownerId: id,
+    });
+    return this.perfilService.setFoto(id, uploaded.url);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
   @Delete()
-  remove(@Request() req) {
+  remove(@Req() req) {
     const id = Number(req.user.id);
     return this.perfilService.remove(id);
   }
@@ -45,7 +83,7 @@ export class PerfilController {
   @Post('seguir/:id')
   seguir(
     @Param('id') id: string,
-    @Request() req
+    @Req() req
   ) {
     const idUsuario = Number(req.user.id);
     return this.perfilService.seguir(Number(id), idUsuario);

--- a/apps/back/src/perfil/perfil.module.ts
+++ b/apps/back/src/perfil/perfil.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { PerfilService } from './perfil.service';
 import { PerfilController } from './perfil.controller';
+import { StorageModule } from '../storage/storage.module';
 
 @Module({
+  imports: [StorageModule],
   controllers: [PerfilController],
   providers: [PerfilService],
   exports: [PerfilService],

--- a/apps/back/src/perfil/perfil.service.spec.ts
+++ b/apps/back/src/perfil/perfil.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PerfilService } from './perfil.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { StorageService } from '../storage/storage.service';
 import { NotFoundException } from '@nestjs/common';
 
 const mockPerfil = {
@@ -41,8 +42,15 @@ describe('PerfilService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PerfilService,
-
         { provide: PrismaService, useValue: mockPrismaService },
+        {
+          provide: StorageService,
+          useValue: {
+            upload: jest.fn(),
+            delete: jest.fn(),
+            getUsage: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/apps/back/src/perfil/perfil.service.ts
+++ b/apps/back/src/perfil/perfil.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { StorageService } from '../storage/storage.service';
 import { UpdatePerfilDto } from './dto/update-perfil.dto';
 import { Prisma, Perfil } from '@prisma/client';
 import { NotFoundException } from '@nestjs/common';
@@ -13,12 +14,16 @@ const perfilSelectPublico = {
   campus: true,
   cargo: true,
   departamento: true,
+  linkFoto: true,
   createdAt: true,
 };
 
 @Injectable()
 export class PerfilService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private readonly storage: StorageService,
+  ) {}
 
   async findAll() {
     return this.prisma.perfil.findMany({
@@ -76,6 +81,21 @@ export class PerfilService {
 
   async findByEmail(email: string) {
     return this.prisma.perfil.findUnique({ where: { email } });
+  }
+
+  async setFoto(id: number, url: string) {
+    try {
+      return await this.prisma.perfil.update({
+        where: { id },
+        data: { linkFoto: url },
+        select: perfilSelectPublico,
+      });
+    } catch (error: any) {
+      if (error.code === 'P2025') {
+        throw new NotFoundException(`Perfil nao encontrado.`);
+      }
+      throw error;
+    }
   }
 
   async create(data: Prisma.PerfilCreateInput): Promise<Perfil> {

--- a/apps/back/src/postagem/postagem.controller.spec.ts
+++ b/apps/back/src/postagem/postagem.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PostagemController } from './postagem.controller';
 import { PostagemService } from './postagem.service';
+import { StorageService } from '../storage/storage.service';
 
 describe('PostagemController', () => {
   let controller: PostagemController;
@@ -24,6 +25,14 @@ describe('PostagemController', () => {
         {
           provide: PostagemService,
           useValue: mockPostagemService,
+        },
+        {
+          provide: StorageService,
+          useValue: {
+            upload: jest.fn(),
+            delete: jest.fn(),
+            getUsage: jest.fn(),
+          },
         },
       ],
     }).compile();

--- a/apps/back/src/postagem/postagem.controller.ts
+++ b/apps/back/src/postagem/postagem.controller.ts
@@ -8,17 +8,25 @@ import {
   Delete,
   Request,
   UseGuards,
+  UseInterceptors,
+  UploadedFile,
+  BadRequestException,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { PostagemService } from './postagem.service';
 import { CreatePostagemDto } from './dto/create-postagem.dto';
 import { UpdatePostagemDto } from './dto/update-postagem.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { ApiBearerAuth } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiConsumes } from '@nestjs/swagger';
 import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
+import { StorageService } from '../storage/storage.service';
 
 @Controller('postagem')
 export class PostagemController {
-  constructor(private readonly postagemService: PostagemService) {}
+  constructor(
+    private readonly postagemService: PostagemService,
+    private readonly storage: StorageService,
+  ) {}
 
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
@@ -26,6 +34,30 @@ export class PostagemController {
   create(@Request()req, @Body() createPostagemDto: CreatePostagemDto) {
     const userId = Number(req.user.id);
     return this.postagemService.create(createPostagemDto, userId);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Post('imagem')
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+      required: ['file'],
+    },
+  })
+  async uploadImagem(
+    @UploadedFile() file: Express.Multer.File,
+    @Request() req,
+  ) {
+    if (!file) throw new BadRequestException('Arquivo "file" eh obrigatorio.');
+    const userId = Number(req.user.id);
+    return this.storage.upload(file.buffer, {
+      slot: 'postagem',
+      ownerId: userId,
+    });
   }
 
   @Get()

--- a/apps/back/src/postagem/postagem.module.ts
+++ b/apps/back/src/postagem/postagem.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { PostagemService } from './postagem.service';
 import { PostagemController } from './postagem.controller';
+import { StorageModule } from '../storage/storage.module';
 
 @Module({
+  imports: [StorageModule],
   controllers: [PostagemController],
   providers: [PostagemService],
   exports: [PostagemService],

--- a/apps/back/src/projeto/projeto.controller.spec.ts
+++ b/apps/back/src/projeto/projeto.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProjetoController } from './projeto.controller';
 import { ProjetoService } from './projeto.service';
+import { StorageService } from '../storage/storage.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 describe('ProjetoController', () => {
@@ -25,7 +26,17 @@ describe('ProjetoController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProjetoController],
-      providers: [{ provide: ProjetoService, useValue: mockProjetoService }],
+      providers: [
+        { provide: ProjetoService, useValue: mockProjetoService },
+        {
+          provide: StorageService,
+          useValue: {
+            upload: jest.fn(),
+            delete: jest.fn(),
+            getUsage: jest.fn(),
+          },
+        },
+      ],
     })
       .overrideGuard(JwtAuthGuard)
       .useValue({ canActivate: () => true }) // Bypassa o guard para testes unitários

--- a/apps/back/src/projeto/projeto.controller.ts
+++ b/apps/back/src/projeto/projeto.controller.ts
@@ -8,15 +8,20 @@ import {
   Delete,
   Request,
   UseGuards,
+  UseInterceptors,
+  UploadedFile,
+  BadRequestException,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { Request as ExpressRequest } from 'express';
-import { ApiBearerAuth } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiConsumes } from '@nestjs/swagger';
 import { ProjetoService } from './projeto.service';
 import { CreateProjetoDto } from './dto/create-projeto.dto';
 import { UpdateProjetoDto } from './dto/update-projeto.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UpdateMembroProjetoDto } from './dto/update-membro-projeto.dto';
 import { AddMembroProjetoDto } from './dto/add-membro-projeto.dto';
+import { StorageService } from '../storage/storage.service';
 
 type AuthenticatedRequest = ExpressRequest & {
   user: { id: string; email: string };
@@ -24,7 +29,10 @@ type AuthenticatedRequest = ExpressRequest & {
 
 @Controller('projeto')
 export class ProjetoController {
-  constructor(private readonly projetoService: ProjetoService) {}
+  constructor(
+    private readonly projetoService: ProjetoService,
+    private readonly storage: StorageService,
+  ) {}
 
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
@@ -110,5 +118,61 @@ export class ProjetoController {
   ) {
     const userId = Number(req.user.id);
     return this.projetoService.removeMembro(+id, userId, +idPerfil);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/foto')
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+      required: ['file'],
+    },
+  })
+  async uploadFoto(
+    @Param('id') id: string,
+    @UploadedFile() file: Express.Multer.File,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    if (!file) throw new BadRequestException('Arquivo "file" eh obrigatorio.');
+    const userId = Number(req.user.id);
+    const uploaded = await this.storage.upload(file.buffer, {
+      slot: 'projeto_foto',
+      ownerId: userId,
+      entityType: 'projeto',
+      entityId: +id,
+    });
+    return this.projetoService.setFoto(+id, userId, uploaded.url);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/banner')
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+      required: ['file'],
+    },
+  })
+  async uploadBanner(
+    @Param('id') id: string,
+    @UploadedFile() file: Express.Multer.File,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    if (!file) throw new BadRequestException('Arquivo "file" eh obrigatorio.');
+    const userId = Number(req.user.id);
+    const uploaded = await this.storage.upload(file.buffer, {
+      slot: 'projeto_banner',
+      ownerId: userId,
+      entityType: 'projeto',
+      entityId: +id,
+    });
+    return this.projetoService.setBanner(+id, userId, uploaded.url);
   }
 }

--- a/apps/back/src/projeto/projeto.module.ts
+++ b/apps/back/src/projeto/projeto.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ProjetoService } from './projeto.service';
 import { ProjetoController } from './projeto.controller';
+import { StorageModule } from '../storage/storage.module';
 
 @Module({
+  imports: [StorageModule],
   controllers: [ProjetoController],
   providers: [ProjetoService],
   exports: [ProjetoService],

--- a/apps/back/src/projeto/projeto.service.ts
+++ b/apps/back/src/projeto/projeto.service.ts
@@ -83,6 +83,22 @@ export class ProjetoService {
     return projetos;
   }
 
+  async setFoto(idProjeto: number, idPerfilSolicitante: number, url: string) {
+    await this.podeEditarProjeto(idProjeto, idPerfilSolicitante);
+    return this.prisma.projeto.update({
+      where: { id: idProjeto },
+      data: { linkFoto: url },
+    });
+  }
+
+  async setBanner(idProjeto: number, idPerfilSolicitante: number, url: string) {
+    await this.podeEditarProjeto(idProjeto, idPerfilSolicitante);
+    return this.prisma.projeto.update({
+      where: { id: idProjeto },
+      data: { linkBanner: url },
+    });
+  }
+
   async findOne(id: number) {
     return this.prisma.projeto.findUnique({
       where: { id },

--- a/apps/back/src/storage/image.processor.ts
+++ b/apps/back/src/storage/image.processor.ts
@@ -1,0 +1,97 @@
+import * as crypto from 'node:crypto';
+import sharp from 'sharp';
+import {
+  ALLOWED_INPUT_MIME,
+  OUTPUT_EXT,
+  OUTPUT_MIME,
+  STORAGE_SLOTS,
+  StorageSlotName,
+} from './storage.constants';
+
+export class ImageProcessor {
+  /**
+   * Detecta o MIME real a partir do buffer (magic bytes). Nao confia no header
+   * enviado pelo cliente.
+   */
+  detectMime(buffer: Buffer): string {
+    if (buffer.length < 12) return 'application/octet-stream';
+    if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff)
+      return 'image/jpeg';
+    if (
+      buffer[0] === 0x89 &&
+      buffer[1] === 0x50 &&
+      buffer[2] === 0x4e &&
+      buffer[3] === 0x47 &&
+      buffer[4] === 0x0d &&
+      buffer[5] === 0x0a &&
+      buffer[6] === 0x1a &&
+      buffer[7] === 0x0a
+    )
+      return 'image/png';
+    if (
+      buffer[0] === 0x52 &&
+      buffer[1] === 0x49 &&
+      buffer[2] === 0x46 &&
+      buffer[3] === 0x46 &&
+      buffer[8] === 0x57 &&
+      buffer[9] === 0x45 &&
+      buffer[10] === 0x42 &&
+      buffer[11] === 0x50
+    )
+      return 'image/webp';
+    return 'application/octet-stream';
+  }
+
+  isAllowed(mime: string): boolean {
+    return ALLOWED_INPUT_MIME.has(mime);
+  }
+
+  /**
+   * Processa a imagem para o slot: redimensiona, corrige orientacao EXIF,
+   * converte para WebP q80. Retorna buffer processado + sha1 para path
+   * deterministico.
+   */
+  async process(
+    buffer: Buffer,
+    slot: StorageSlotName,
+  ): Promise<{
+    buffer: Buffer;
+    hash: string;
+    mimeType: string;
+  }> {
+    const cfg = STORAGE_SLOTS[slot];
+    const pipeline = sharp(buffer, { failOn: 'error' }).rotate().resize({
+      width: cfg.width,
+      height: cfg.height,
+      fit: cfg.fit,
+      withoutEnlargement: true,
+    });
+
+    const processed = await pipeline.webp({ quality: 80 }).toBuffer();
+    const hash = crypto
+      .createHash('sha1')
+      .update(processed)
+      .digest('hex')
+      .slice(0, 16);
+    return { buffer: processed, hash, mimeType: OUTPUT_MIME };
+  }
+
+  /**
+   * Monta a chave canônica no bucket: `<slot>/<ownerId>/<entityId?>/<hash>.webp`.
+   * O hash garante path deterministico (dedup: mesmo arquivo = mesma chave).
+   */
+  buildKey(args: {
+    slot: StorageSlotName;
+    ownerId: number;
+    hash: string;
+    entityType?: string | null;
+    entityId?: number | null;
+  }): string {
+    const segments = [args.slot, String(args.ownerId)];
+    if (args.entityType && args.entityId != null) {
+      segments.push(`${args.entityType}-${args.entityId}`);
+    }
+    segments.push(`${args.hash}.${OUTPUT_EXT}`);
+    return segments.join('/');
+  }
+}

--- a/apps/back/src/storage/providers/local.provider.ts
+++ b/apps/back/src/storage/providers/local.provider.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { StorageProvider } from '../storage.types';
+
+const UPLOAD_ROOT = path.resolve(process.cwd(), 'apps/back/uploads');
+
+@Injectable()
+export class LocalStorageProvider implements StorageProvider {
+  private readonly logger = new Logger(LocalStorageProvider.name);
+
+  private get publicBaseUrl(): string {
+    return (
+      process.env.BACKEND_PUBLIC_BASE_URL ?? 'http://localhost:3000'
+    ).replace(/\/$/, '');
+  }
+
+  async upload(args: {
+    buffer: Buffer;
+    key: string;
+    contentType: string;
+    cacheControl: string;
+  }): Promise<{ url: string }> {
+    const absPath = path.join(UPLOAD_ROOT, args.key);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, args.buffer);
+    return { url: `${this.publicBaseUrl}/uploads/${args.key}` };
+  }
+
+  async delete(args: { key: string }): Promise<void> {
+    const absPath = path.join(UPLOAD_ROOT, args.key);
+    try {
+      await fs.unlink(absPath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== 'ENOENT') {
+        this.logger.warn(`local delete falhou key=${args.key}: ${code}`);
+      }
+    }
+  }
+}
+
+export const LOCAL_UPLOAD_ROOT = UPLOAD_ROOT;

--- a/apps/back/src/storage/providers/r2.provider.ts
+++ b/apps/back/src/storage/providers/r2.provider.ts
@@ -1,0 +1,70 @@
+import {
+  DeleteObjectCommand,
+  PutObjectCommand,
+  S3Client,
+  S3ServiceException,
+} from '@aws-sdk/client-s3';
+import { Injectable, Logger } from '@nestjs/common';
+import { CACHE_CONTROL_IMMUTABLE } from '../storage.constants';
+import { StorageProvider } from '../storage.types';
+
+@Injectable()
+export class R2StorageProvider implements StorageProvider {
+  private readonly logger = new Logger(R2StorageProvider.name);
+  private readonly client: S3Client;
+  private readonly bucket: string;
+  private readonly publicUrl: string;
+
+  constructor() {
+    this.bucket = process.env.R2_BUCKET_NAME!;
+    this.publicUrl = (process.env.R2_PUBLIC_URL ?? '').replace(/\/$/, '');
+    this.client = new S3Client({
+      region: process.env.R2_REGION ?? 'auto',
+      endpoint: process.env.R2_ENDPOINT,
+      credentials: {
+        accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+        secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+      },
+      forcePathStyle: false,
+    });
+  }
+
+  async upload(args: {
+    buffer: Buffer;
+    key: string;
+    contentType: string;
+    cacheControl: string;
+  }): Promise<{ url: string }> {
+    const command = new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: args.key,
+      Body: args.buffer,
+      ContentType: args.contentType,
+      CacheControl: CACHE_CONTROL_IMMUTABLE,
+    });
+    try {
+      await this.client.send(command);
+    } catch (err) {
+      if (err instanceof S3ServiceException) {
+        this.logger.error(
+          `R2 upload falhou key=${args.key}: ${err.name} ${err.message}`,
+        );
+      }
+      throw err;
+    }
+    return { url: `${this.publicUrl}/${args.key}` };
+  }
+
+  async delete(args: { key: string }): Promise<void> {
+    try {
+      await this.client.send(
+        new DeleteObjectCommand({ Bucket: this.bucket, Key: args.key }),
+      );
+    } catch (err) {
+      // Idempotente: se já não existia, loga e segue.
+      if (err instanceof S3ServiceException) {
+        this.logger.warn(`R2 delete falhou key=${args.key}: ${err.name}`);
+      }
+    }
+  }
+}

--- a/apps/back/src/storage/storage.constants.ts
+++ b/apps/back/src/storage/storage.constants.ts
@@ -1,0 +1,89 @@
+export type StorageSlotName =
+  | 'avatar'
+  | 'logo'
+  | 'banner'
+  | 'postagem'
+  | 'projeto_foto'
+  | 'projeto_banner'
+  | 'processo_foto';
+
+export interface StorageSlot {
+  name: StorageSlotName;
+  width: number;
+  height: number;
+  fit: 'cover' | 'inside';
+  maxSizeBytes: number;
+  single: boolean;
+}
+
+export const STORAGE_SLOTS: Record<StorageSlotName, StorageSlot> = {
+  avatar: {
+    name: 'avatar',
+    width: 256,
+    height: 256,
+    fit: 'cover',
+    maxSizeBytes: 2 * 1024 * 1024,
+    single: true,
+  },
+  logo: {
+    name: 'logo',
+    width: 256,
+    height: 256,
+    fit: 'inside',
+    maxSizeBytes: 2 * 1024 * 1024,
+    single: true,
+  },
+  banner: {
+    name: 'banner',
+    width: 1280,
+    height: 400,
+    fit: 'cover',
+    maxSizeBytes: 3 * 1024 * 1024,
+    single: true,
+  },
+  postagem: {
+    name: 'postagem',
+    width: 1080,
+    height: 1080,
+    fit: 'inside',
+    maxSizeBytes: 4 * 1024 * 1024,
+    single: false,
+  },
+  projeto_foto: {
+    name: 'projeto_foto',
+    width: 1080,
+    height: 720,
+    fit: 'cover',
+    maxSizeBytes: 3 * 1024 * 1024,
+    single: true,
+  },
+  projeto_banner: {
+    name: 'projeto_banner',
+    width: 1280,
+    height: 400,
+    fit: 'cover',
+    maxSizeBytes: 3 * 1024 * 1024,
+    single: true,
+  },
+  processo_foto: {
+    name: 'processo_foto',
+    width: 1080,
+    height: 720,
+    fit: 'cover',
+    maxSizeBytes: 3 * 1024 * 1024,
+    single: true,
+  },
+};
+
+export const ALLOWED_INPUT_MIME = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+export const OUTPUT_MIME = 'image/webp';
+export const OUTPUT_EXT = 'webp';
+
+export const DEFAULT_UPLOAD_MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+export const DEFAULT_PERFIL_STORAGE_QUOTA_BYTES = 50 * 1024 * 1024;
+export const CACHE_CONTROL_IMMUTABLE = 'public, max-age=31536000, immutable';

--- a/apps/back/src/storage/storage.controller.ts
+++ b/apps/back/src/storage/storage.controller.ts
@@ -1,7 +1,123 @@
-import { Controller } from '@nestjs/common';
+import {
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+  Req,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+  BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiBearerAuth, ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger';
+import { Request as ExpressRequest } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { StorageSlotName } from './storage.constants';
 import { StorageService } from './storage.service';
 
+type AuthenticatedRequest = ExpressRequest & {
+  user: { id: string; email: string };
+};
+
+@ApiBearerAuth()
+@ApiTags('Storage')
 @Controller('storage')
 export class StorageController {
   constructor(private readonly storageService: StorageService) {}
+
+  @Post('upload')
+  @UseGuards(JwtAuthGuard)
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: {
+        fileSize: Number.parseInt(
+          process.env.UPLOAD_MAX_FILE_SIZE_BYTES ?? '5242880',
+          10,
+        ),
+      },
+      fileFilter: (_req, file, cb) => {
+        if (!file.mimetype.startsWith('image/')) {
+          return cb(
+            new BadRequestException('Apenas imagens sao permitidas.'),
+            false,
+          );
+        }
+        cb(null, true);
+      },
+    }),
+  )
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary' },
+      },
+      required: ['file'],
+    },
+  })
+  async upload(
+    @UploadedFile() file: Express.Multer.File,
+    @Query('slot') slot: string,
+    @Query('entityId') entityId: string | undefined,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    if (!file) throw new BadRequestException('Arquivo "file" eh obrigatorio.');
+    const validSlots: StorageSlotName[] = [
+      'avatar',
+      'logo',
+      'banner',
+      'postagem',
+      'projeto_foto',
+      'projeto_banner',
+      'processo_foto',
+    ];
+    if (!validSlots.includes(slot as StorageSlotName)) {
+      throw new BadRequestException(`Slot invalido: ${slot}`);
+    }
+
+    const slotName = slot as StorageSlotName;
+    const ownerId = Number(req.user.id);
+
+    const ctx: {
+      slot: StorageSlotName;
+      ownerId: number;
+      entityType?: string;
+      entityId?: number;
+    } = {
+      slot: slotName,
+      ownerId,
+    };
+
+    // Mapeia slot -> (entityType, entityId) para dedup/substituicao por entidade.
+    if (entityId) {
+      const eid = Number(entityId);
+      if (slotName === 'logo' || slotName === 'banner')
+        ctx.entityType = 'entidade';
+      else if (slotName === 'projeto_foto' || slotName === 'projeto_banner')
+        ctx.entityType = 'projeto';
+      else if (slotName === 'postagem') ctx.entityType = 'postagem';
+      else if (slotName === 'processo_foto')
+        ctx.entityType = 'processo_seletivo';
+      if (ctx.entityType) ctx.entityId = eid;
+    }
+
+    return this.storageService.upload(file.buffer, ctx);
+  }
+
+  @Get('usage/:perfilId')
+  @UseGuards(JwtAuthGuard)
+  usage(@Param('perfilId') perfilId: string) {
+    return this.storageService.getUsage(Number(perfilId));
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  async remove(@Param('id') id: string, @Req() req: AuthenticatedRequest) {
+    await this.storageService.delete(id, Number(req.user.id));
+    return { ok: true };
+  }
 }

--- a/apps/back/src/storage/storage.module.ts
+++ b/apps/back/src/storage/storage.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { StorageController } from './storage.controller';
 import { StorageService } from './storage.service';
+import { R2StorageProvider } from './providers/r2.provider';
+import { LocalStorageProvider } from './providers/local.provider';
 import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
   imports: [PrismaModule],
   controllers: [StorageController],
-  providers: [StorageService],
+  providers: [StorageService, R2StorageProvider, LocalStorageProvider],
   exports: [StorageService],
 })
 export class StorageModule {}

--- a/apps/back/src/storage/storage.service.ts
+++ b/apps/back/src/storage/storage.service.ts
@@ -1,7 +1,288 @@
-import { Injectable } from '@nestjs/common';
+/* eslint-disable @typescript-eslint/no-redundant-type-constituents */
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { File, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { ImageProcessor } from './image.processor';
+import { R2StorageProvider } from './providers/r2.provider';
+import { LocalStorageProvider } from './providers/local.provider';
+import {
+  CACHE_CONTROL_IMMUTABLE,
+  DEFAULT_PERFIL_STORAGE_QUOTA_BYTES,
+  DEFAULT_UPLOAD_MAX_FILE_SIZE_BYTES,
+  STORAGE_SLOTS,
+  StorageSlotName,
+} from './storage.constants';
+import {
+  StorageProvider,
+  StorageUploadResult,
+  UploadContext,
+} from './storage.types';
 
 @Injectable()
 export class StorageService {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly logger = new Logger(StorageService.name);
+  private readonly provider: StorageProvider;
+  private readonly imageProcessor = new ImageProcessor();
+
+  constructor(
+    private readonly r2: R2StorageProvider,
+    private readonly local: LocalStorageProvider,
+    private readonly prisma: PrismaService,
+  ) {
+    this.provider = this.resolveProvider();
+  }
+
+  private resolveProvider(): StorageProvider {
+    const driver = (process.env.STORAGE_DRIVER ?? '').toLowerCase();
+    if (driver === 'r2') return this.r2;
+    if (driver === 'local') return this.local;
+    // auto-detect
+    if (process.env.R2_BUCKET_NAME && process.env.R2_ENDPOINT) return this.r2;
+    return this.local;
+  }
+
+  private get maxFileSize(): number {
+    const parsed = Number.parseInt(
+      process.env.UPLOAD_MAX_FILE_SIZE_BYTES ??
+        String(DEFAULT_UPLOAD_MAX_FILE_SIZE_BYTES),
+      10,
+    );
+    return Number.isFinite(parsed) && parsed > 0
+      ? parsed
+      : DEFAULT_UPLOAD_MAX_FILE_SIZE_BYTES;
+  }
+
+  private get perfilQuota(): number {
+    const parsed = Number.parseInt(
+      process.env.PERFIL_STORAGE_QUOTA_BYTES ??
+        String(DEFAULT_PERFIL_STORAGE_QUOTA_BYTES),
+      10,
+    );
+    return Number.isFinite(parsed) && parsed > 0
+      ? parsed
+      : DEFAULT_PERFIL_STORAGE_QUOTA_BYTES;
+  }
+
+  async upload(
+    buffer: Buffer,
+    ctx: UploadContext,
+  ): Promise<StorageUploadResult> {
+    const slotCfg = STORAGE_SLOTS[ctx.slot];
+    if (!slotCfg) {
+      throw new BadRequestException(`Slot desconhecido: ${ctx.slot}`);
+    }
+
+    if (buffer.length === 0) {
+      throw new BadRequestException('Arquivo vazio.');
+    }
+    if (buffer.length > this.maxFileSize) {
+      throw new BadRequestException(
+        `Arquivo excede o tamanho maximo de ${this.maxFileSize} bytes.`,
+      );
+    }
+
+    const mime = this.imageProcessor.detectMime(buffer);
+    if (!this.imageProcessor.isAllowed(mime)) {
+      throw new BadRequestException(
+        `Tipo de arquivo nao suportado (${mime}). Use JPEG, PNG ou WebP.`,
+      );
+    }
+
+    const processed = await this.imageProcessor.process(buffer, ctx.slot);
+
+    if (processed.buffer.length > slotCfg.maxSizeBytes) {
+      throw new BadRequestException(
+        `Imagem processada ainda muito grande para o slot "${ctx.slot}" (${processed.buffer.length} bytes).`,
+      );
+    }
+
+    await this.assertQuota(ctx.ownerId, processed.buffer.length);
+
+    const key = this.imageProcessor.buildKey({
+      slot: ctx.slot,
+      ownerId: ctx.ownerId,
+      hash: processed.hash,
+      entityType: ctx.entityType,
+      entityId: ctx.entityId,
+    });
+
+    // Dedup: se a chave já existe no R2/local, reusamos. Caso contrario subimos.
+    const existing = await this.prisma.file.findUnique({ where: { key } });
+    if (existing) {
+      return {
+        fileId: existing.id,
+        key: existing.key,
+        url: existing.url,
+        size: existing.size,
+        mimeType: existing.mimeType,
+      };
+    }
+
+    const { url } = await this.provider.upload({
+      buffer: processed.buffer,
+      key,
+      contentType: processed.mimeType,
+      cacheControl: CACHE_CONTROL_IMMUTABLE,
+    });
+
+    // Slot single: substitui o anterior (deleta R2 + File row) dentro de tx.
+    let fileRow: File;
+    if (slotCfg.single) {
+      fileRow = await this.replaceSingleSlot({
+        key,
+        url,
+        size: processed.buffer.length,
+        mimeType: processed.mimeType,
+        originalNameHint: ctx.slot,
+        ctx,
+      });
+    } else {
+      fileRow = await this.prisma.file.create({
+        data: {
+          key,
+          url,
+          size: processed.buffer.length,
+          mimeType: processed.mimeType,
+          slot: ctx.slot,
+          ownerId: ctx.ownerId,
+          entityType: ctx.entityType ?? null,
+          entityId: ctx.entityId ?? null,
+          originalName: `${ctx.slot}-${processed.hash}`,
+        },
+      });
+    }
+
+    return {
+      fileId: fileRow.id,
+      key: fileRow.key,
+      url: fileRow.url,
+      size: fileRow.size,
+      mimeType: fileRow.mimeType,
+    };
+  }
+
+  async delete(fileId: string, requesterId: number): Promise<void> {
+    const file = await this.prisma.file.findUnique({ where: { id: fileId } });
+    if (!file) throw new NotFoundException('Arquivo nao encontrado.');
+    if (file.ownerId !== requesterId) {
+      // Permite delecao por gestores da entidade dona via camada de dominio.
+      // Aqui, sem contexto de entidade, so o dono.
+      throw new NotFoundException('Arquivo nao encontrado.');
+    }
+    await this.provider.delete({ key: file.key });
+    await this.prisma.file.delete({ where: { id: fileId } });
+  }
+
+  async findByUrl(url: string): Promise<File | null> {
+    return this.prisma.file.findFirst({ where: { url } });
+  }
+
+  async findByOwnerSlot(
+    ownerId: number,
+    slot: StorageSlotName,
+  ): Promise<File[]> {
+    return this.prisma.file.findMany({ where: { ownerId, slot } });
+  }
+
+  async deleteByKey(key: string): Promise<void> {
+    await this.provider.delete({ key });
+    try {
+      await this.prisma.file.delete({ where: { key } });
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2025'
+      ) {
+        return;
+      }
+      throw err;
+    }
+  }
+
+  async getUsage(perfilId: number): Promise<{
+    used: number;
+    quota: number;
+    percent: number;
+  }> {
+    const agg = await this.prisma.file.aggregate({
+      where: { ownerId: perfilId },
+      _sum: { size: true },
+    });
+    const used = agg._sum.size ?? 0;
+    const quota = this.perfilQuota;
+    return { used, quota, percent: quota > 0 ? (used / quota) * 100 : 0 };
+  }
+
+  private async assertQuota(ownerId: number, incomingBytes: number) {
+    const { used, quota } = await this.getUsage(ownerId);
+    if (used + incomingBytes > quota) {
+      throw new BadRequestException(
+        `Upload excederia a quota de armazenamento do perfil (${used + incomingBytes} > ${quota} bytes).`,
+      );
+    }
+  }
+
+  private async replaceSingleSlot(args: {
+    key: string;
+    url: string;
+    size: number;
+    mimeType: string;
+    originalNameHint: string;
+    ctx: UploadContext;
+  }): Promise<File> {
+    const where: Prisma.FileWhereInput = {
+      ownerId: args.ctx.ownerId,
+      slot: args.ctx.slot,
+    };
+    if (args.ctx.entityType && args.ctx.entityId != null) {
+      where.entityType = args.ctx.entityType;
+      where.entityId = args.ctx.entityId;
+    }
+    const previous = await this.prisma.file.findFirst({ where });
+
+    const created = await this.prisma.file.create({
+      data: {
+        key: args.key,
+        url: args.url,
+        size: args.size,
+        mimeType: args.mimeType,
+        slot: args.ctx.slot,
+        ownerId: args.ctx.ownerId,
+        entityType: args.ctx.entityType ?? null,
+        entityId: args.ctx.entityId ?? null,
+        originalName: `${args.originalNameHint}-${args.key.split('/').pop()}`,
+      },
+    });
+
+    if (
+      previous &&
+      previous.id !== created.id &&
+      previous.key !== created.key
+    ) {
+      await this.provider.delete({ key: previous.key }).catch((err) => {
+        this.logger.warn(
+          `falha ao remover arquivo anterior: ${previous.key} -> ${err}`,
+        );
+      });
+      await this.prisma.file
+        .delete({ where: { id: previous.id } })
+        .catch((err) => {
+          if (
+            err instanceof Prisma.PrismaClientKnownRequestError &&
+            err.code === 'P2025'
+          ) {
+            return;
+          }
+          this.logger.warn(
+            `falha ao remover File row anterior: ${previous.id}`,
+          );
+        });
+    }
+    return created;
+  }
 }

--- a/apps/back/src/storage/storage.types.ts
+++ b/apps/back/src/storage/storage.types.ts
@@ -1,0 +1,26 @@
+import { StorageSlotName } from './storage.constants';
+
+export interface StorageUploadResult {
+  fileId: string;
+  key: string;
+  url: string;
+  size: number;
+  mimeType: string;
+}
+
+export interface StorageProvider {
+  upload(args: {
+    buffer: Buffer;
+    key: string;
+    contentType: string;
+    cacheControl: string;
+  }): Promise<{ url: string }>;
+  delete(args: { key: string }): Promise<void>;
+}
+
+export interface UploadContext {
+  slot: StorageSlotName;
+  ownerId: number;
+  entityType?: string | null;
+  entityId?: number | null;
+}

--- a/apps/front/app/conecta/entidades/[id]/page.tsx
+++ b/apps/front/app/conecta/entidades/[id]/page.tsx
@@ -469,8 +469,8 @@ useEffect(() => {
         <CriarProjetoModal
           isOpen={isCriarProjetoModalOpen}
           onClose={() => setIsCriarProjetoModalOpen(false)}
-          idEntidade={entidade.id}
-          onSuccess={recarregarProjetos}
+          entidades={[{ id: entidade.id, nome: entidade.nome }]}
+          onCreated={recarregarProjetos}
         />
       )}
       {entidade && (

--- a/apps/front/app/conecta/entidades/gestao/page.tsx
+++ b/apps/front/app/conecta/entidades/gestao/page.tsx
@@ -1,6 +1,7 @@
 "use client";
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { Search, User } from 'lucide-react';
 import { ButtonGreen } from '@/components/ButtonGreen';
 import { ProjetoCard } from '@/components/entidade/projetoCard';
 import { CreateEntidadeModal } from '@/components/entidade/CreateEntidadeModal';
@@ -25,6 +26,14 @@ type EntidadeResumo = {
   vinculo: VinculoEntidade;
 };
 
+type EntidadeBusca = {
+  id: number;
+  nome: string;
+  classificacao: string;
+  campus: string;
+  linkLogo: string | null;
+};
+
 export default function EntidadesPage() {
   const router = useRouter();
 
@@ -37,6 +46,15 @@ export default function EntidadesPage() {
   const [entidadesCogestao, setEntidadesCogestao] = useState<EntidadeResumo[]>([]);
   const [entidadesMembro, setEntidadesMembro] = useState<EntidadeResumo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<EntidadeBusca[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [showResults, setShowResults] = useState(false);
+  const [followingIds, setFollowingIds] = useState<Set<number>>(new Set());
+
+  const searchRef = useRef<HTMLDivElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const fetchEntidades = useCallback(async () => {
     try {
@@ -57,10 +75,133 @@ export default function EntidadesPage() {
     fetchEntidades();
   }, [fetchEntidades]);
 
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!searchQuery.trim()) {
+      setSearchResults([]);
+      setShowResults(false);
+      return;
+    }
+    debounceRef.current = setTimeout(async () => {
+      setIsSearching(true);
+      try {
+        const res = await api.get('/entidade/buscar', { params: { q: searchQuery } });
+        setSearchResults(res.data);
+        setShowResults(true);
+      } catch {
+        setSearchResults([]);
+      } finally {
+        setIsSearching(false);
+      }
+    }, 300);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (searchRef.current && !searchRef.current.contains(e.target as Node)) {
+        setShowResults(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSeguir = async (id: number) => {
+    try {
+      await api.post(`/entidade/${id}/seguir`);
+      setFollowingIds((prev) => new Set(prev).add(id));
+    } catch {
+      console.error('Erro ao seguir entidade');
+    }
+  };
+
+  const classLabel = (c: string) =>
+    c.replaceAll('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase());
+
   return (
     <div className="flex min-h-screen bg-[#fafafa]">
       <main className="flex-1 p-12">
-        <div className="flex justify-end mb-12">
+        <div className="flex justify-between items-center mb-12 gap-4">
+          <div ref={searchRef} className="relative flex-1 max-w-md">
+            <div className="relative">
+              <Search
+                size={18}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
+              />
+              <input
+                type="text"
+                placeholder="Buscar entidades..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onFocus={() => { if (searchResults.length > 0) setShowResults(true); }}
+                className="w-full pl-10 pr-4 py-3 rounded-md border border-gray-300 bg-white text-[#0d2a54] placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#195b3d] focus:border-transparent text-sm"
+              />
+              {isSearching && (
+                <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                  <div className="w-4 h-4 border-2 border-[#195b3d] border-t-transparent rounded-full animate-spin" />
+                </div>
+              )}
+            </div>
+            {showResults && (
+              <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-gray-200 rounded-xl shadow-lg z-50 max-h-80 overflow-y-auto">
+                {searchResults.length > 0 ? (
+                  searchResults.map((entidade) => (
+                    <div
+                      key={entidade.id}
+                      className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 border-b border-gray-100 last:border-b-0"
+                    >
+                      <div
+                        className="flex-1 flex items-center gap-3 min-w-0 cursor-pointer"
+                        onClick={() => {
+                          setShowResults(false);
+                          router.push(`/conecta/entidades/${entidade.id}`);
+                        }}
+                      >
+                        {entidade.linkLogo ? (
+                          <img
+                            src={entidade.linkLogo}
+                            alt={entidade.nome}
+                            className="w-10 h-10 rounded-full object-cover flex-shrink-0"
+                          />
+                        ) : (
+                          <div className="w-10 h-10 rounded-full bg-gray-200 flex-shrink-0 flex items-center justify-center text-gray-400">
+                            <User size={20} />
+                          </div>
+                        )}
+                        <div className="min-w-0">
+                          <p className="font-medium text-[#0d2a54] text-sm truncate">
+                            {entidade.nome}
+                          </p>
+                          <p className="text-xs text-gray-500 truncate">
+                            {classLabel(entidade.classificacao)} &middot; {entidade.campus}
+                          </p>
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleSeguir(entidade.id);
+                        }}
+                        disabled={followingIds.has(entidade.id)}
+                        className={`flex-shrink-0 px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                          followingIds.has(entidade.id)
+                            ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+                            : 'bg-[#195b3d] text-white hover:bg-[#13472f]'
+                        }`}
+                      >
+                        {followingIds.has(entidade.id) ? 'Seguindo' : 'Seguir'}
+                      </button>
+                    </div>
+                  ))
+                ) : (
+                  <p className="px-4 py-6 text-center text-sm text-gray-500">
+                    Nenhuma entidade encontrada.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
           <ButtonGreen text="Criar Entidade" onClick={() => setIsCreateModalOpen(true)} />
         </div>
 

--- a/apps/front/app/conecta/perfil/[id]/page.tsx
+++ b/apps/front/app/conecta/perfil/[id]/page.tsx
@@ -8,6 +8,8 @@ import { useParams, useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { CAMPUS_OPTIONS, CURSO_OPTIONS, DEPARTAMENTO_OPTIONS } from "@/constants/options";
 import {ConfirmModal} from "@/components/ConfirmModal";
+import { ImageUploadBox } from "@/components/ImageUploadBox";
+import { uploadImage } from "@/lib/upload";
 
 export default function PerfilPage() {
   const { user, logout } = useAuth();
@@ -26,12 +28,15 @@ export default function PerfilPage() {
   >([]);
 
   const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [pendingFoto, setPendingFoto] = useState<File | null>(null);
   const [formData, setFormData] = useState({
     name: "",
     matricula: "",
     campus: "",
     curso: "",
     departamento: "",
+    linkFoto: "" as string | null | undefined,
   });
 
   const fetchDados = async () => {
@@ -56,6 +61,7 @@ export default function PerfilPage() {
 
   const handleCancelEdit = () => {
     setIsEditing(false);
+    setPendingFoto(null);
     fetchDados();
   };
 
@@ -69,14 +75,34 @@ export default function PerfilPage() {
   };
 
   const handleSave = async () => {
+    setIsSaving(true);
     try {
-      const payload = { ...formData };
+      let linkFoto = formData.linkFoto;
+      if (pendingFoto) {
+        const uploaded = await uploadImage(pendingFoto, "avatar");
+        linkFoto = uploaded.url;
+      }
+
+      const payload = {
+        name: formData.name,
+        matricula: formData.matricula,
+        campus: formData.campus,
+        curso: formData.curso,
+        departamento: formData.departamento,
+      };
       await api.patch(`/perfil`, payload);
+
+      if (pendingFoto && linkFoto) {
+        setFormData((prev) => ({ ...prev, linkFoto }));
+      }
+      setPendingFoto(null);
       toast.success("Edição concluída com sucesso");
       setIsEditing(false);
     } catch (error: unknown) {
       console.error("Erro ao salvar perfil:", error);
       toast.error("Ocorreu um erro ao tentar salvar as alterações.");
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -101,11 +127,32 @@ export default function PerfilPage() {
       <main className="flex-1 p-8 sm:p-12 flex justify-center">
         <div className="w-full max-w-4xl space-y-16">
           <div className="flex flex-col md:flex-row items-center justify-between gap-8 bg-white">
-            
+
             {/* foto */}
-            <div className="w-48 h-48 rounded-full bg-gray-200 flex items-center justify-center text-gray-500 font-medium text-lg border border-gray-300 flex-shrink-0">
-              Foto
-            </div>
+            {isEditing && isOwner ? (
+              <div className="w-48 flex-shrink-0">
+                <ImageUploadBox
+                  id="avatar-upload"
+                  label="Foto de Perfil"
+                  file={pendingFoto}
+                  onChange={setPendingFoto}
+                  imageClassName="object-cover rounded-full"
+                />
+              </div>
+            ) : (
+              <div className="w-48 h-48 rounded-full bg-gray-200 flex items-center justify-center text-gray-500 font-medium text-lg border border-gray-300 flex-shrink-0 overflow-hidden">
+                {formData.linkFoto ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={formData.linkFoto}
+                    alt="Foto de perfil"
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  "Foto"
+                )}
+              </div>
+            )}
 
             {/* dados perfil */}
             <div className="flex-1 w-full space-y-4 max-w-md">
@@ -199,13 +246,15 @@ export default function PerfilPage() {
                   <>
                     <button
                       onClick={handleSave}
-                      className="px-6 py-2.5 bg-[#006633] text-white font-medium rounded-full hover:bg-[#004d26] transition-colors whitespace-nowrap"
+                      disabled={isSaving}
+                      className="px-6 py-2.5 bg-[#006633] text-white font-medium rounded-full hover:bg-[#004d26] transition-colors whitespace-nowrap disabled:opacity-60"
                     >
-                      Salvar Alterações
+                      {isSaving ? "Salvando..." : "Salvar Alterações"}
                     </button>
                     <button
                       onClick={handleCancelEdit}
-                      className="px-6 py-2.5 bg-gray-500 text-white font-medium rounded-full hover:bg-gray-600 transition-colors whitespace-nowrap"
+                      disabled={isSaving}
+                      className="px-6 py-2.5 bg-gray-500 text-white font-medium rounded-full hover:bg-gray-600 transition-colors whitespace-nowrap disabled:opacity-60"
                     >
                       Cancelar
                     </button>

--- a/apps/front/components/CreateProjetoModal.tsx
+++ b/apps/front/components/CreateProjetoModal.tsx
@@ -1,205 +1,253 @@
-import { useState } from 'react';
-import { X } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { X, Trash2 } from 'lucide-react';
 import { api } from '@/guards/api';
-import { StatusProjeto } from '@/constants/options'; 
-import { ImageUploadBox } from '@/components//ImageUploadBox';
+import { ImageUploadBox } from '@/components/ImageUploadBox';
 
-type CriarProjetoModalProps = {
+type CreateProjetoModalProps = {
   isOpen: boolean;
+  entidades: { id: number; nome: string }[];
+  projeto?: {
+    id: number;
+    idEntidade: number;
+    nome: string;
+    descricao?: string | null;
+    status?: string;
+    dataInicio?: string;
+    dataFim?: string | null;
+    linkFoto?: string | null;
+    linkBanner?: string | null;
+  } | null;
   onClose: () => void;
-  idEntidade: number;
-  onSuccess: () => void;
+  onCreated: () => void;
 };
 
-export function CriarProjetoModal({ isOpen, onClose, idEntidade, onSuccess }: CriarProjetoModalProps) {
-  const [nome, setNome] = useState('');
-  const [descricao, setDescricao] = useState('');
-  const [foto, setFoto] = useState<File | null>(null);
-  const [status, setStatus] = useState('PLANEJAMENTO');
-  const [dataInicio, setDataInicio] = useState('');
-  const [dataFim, setDataFim] = useState('');
-  
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
+function getErrorMessage(error: unknown) {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    typeof error.response === 'object' &&
+    error.response !== null &&
+    'data' in error.response &&
+    typeof error.response.data === 'object' &&
+    error.response.data !== null &&
+    'message' in error.response.data
+  ) {
+    const message = error.response.data.message;
+    return Array.isArray(message) ? message.join('\n') : String(message);
+  }
+  return 'Não foi possível criar o projeto. Tente novamente.';
+}
+
+export function CreateProjetoModal({
+  isOpen,
+  entidades,
+  projeto,
+  onClose,
+  onCreated,
+}: CreateProjetoModalProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [pendingFoto, setPendingFoto] = useState<File | null>(null);
+  const [pendingBanner, setPendingBanner] = useState<File | null>(null);
+  const [formData, setFormData] = useState({
+    idEntidade: '',
+    nome: '',
+    descricao: '',
+    status: 'PLANEJAMENTO',
+    dataInicio: '',
+    dataFim: '',
+  });
+  const isEditing = Boolean(projeto);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setErrorMessage('');
+    setPendingFoto(null);
+    setPendingBanner(null);
+    setFormData({
+      idEntidade: projeto?.idEntidade ? String(projeto.idEntidade) : '',
+      nome: projeto?.nome ?? '',
+      descricao: projeto?.descricao ?? '',
+      status: projeto?.status ?? 'PLANEJAMENTO',
+      dataInicio: projeto?.dataInicio ? projeto.dataInicio.slice(0, 10) : '',
+      dataFim: projeto?.dataFim ? projeto.dataFim.slice(0, 10) : '',
+    });
+  }, [isOpen, projeto]);
 
   if (!isOpen) return null;
 
-  // Função simulada para o upload na Cloudflare
-  const uploadParaCloudflare = async (arquivo: File): Promise<string> => {
-    
-    console.log("Fazendo upload para a Cloudflare...", arquivo.name);
-    return "https://link-ficticio-da-cloudflare.com/imagem.png"; 
+  const handleDelete = async () => {
+    if (!projeto) return;
+    setIsLoading(true);
+    try {
+      await api.delete(`/projeto/${projeto.id}`);
+      onCreated();
+      onClose();
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setLoading(true);
-    setError('');
+    setIsLoading(true);
+    setErrorMessage('');
 
     try {
-      let linkDaFotoGerado = '';
-
-      if (foto) {
-        linkDaFotoGerado = await uploadParaCloudflare(foto);
-      }
-
-      const inicioIso = dataInicio ? new Date(`${dataInicio}T00:00:00`).toISOString() : undefined;
-      const fimIso = dataFim ? new Date(`${dataFim}T00:00:00`).toISOString() : undefined;
-
-      const payload = {
-        idEntidade: Number(idEntidade),
-        nome: nome,
-        descricao: descricao,
-        linkFoto: linkDaFotoGerado || undefined,
-        status: status,
-        dataInicio: inicioIso,
-        dataFim: fimIso,
+      const payload: Record<string, unknown> = {
+        nome: formData.nome,
+        descricao: formData.descricao,
+        status: formData.status,
+        dataInicio: formData.dataInicio ? new Date(`${formData.dataInicio}T00:00:00`).toISOString() : undefined,
+        dataFim: formData.dataFim ? new Date(`${formData.dataFim}T00:00:00`).toISOString() : undefined,
       };
 
-      await api.post('/projeto', payload);
+      const uploadFile = async (id: number, file: File, slot: string) => {
+        const fd = new FormData();
+        fd.append('file', file);
+        await api.post(`/projeto/${id}/${slot}`, fd, {
+          headers: { 'Content-Type': 'multipart/form-data' },
+          timeout: 30000,
+        });
+      };
 
-      setNome('');
-      setDescricao('');
-      setFoto(null);
-      setStatus('PLANEJAMENTO');
-      setDataInicio('');
-      setDataFim('');
+      if (projeto) {
+        await api.patch(`/projeto/${projeto.id}`, payload);
+        const pid = projeto.id;
+        if (pendingFoto) await uploadFile(pid, pendingFoto, 'foto');
+        if (pendingBanner) await uploadFile(pid, pendingBanner, 'banner');
+      } else {
+        const { data: created } = await api.post('/projeto', {
+          ...payload,
+          idEntidade: Number(formData.idEntidade),
+        });
+        if (pendingFoto) await uploadFile(created.id, pendingFoto, 'foto');
+        if (pendingBanner) await uploadFile(created.id, pendingBanner, 'banner');
+      }
 
-      onSuccess();
+      setFormData({ idEntidade: '', nome: '', descricao: '', status: 'PLANEJAMENTO', dataInicio: '', dataFim: '' });
+      setPendingFoto(null);
+      setPendingBanner(null);
+      onCreated();
       onClose();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
-      console.error('Erro ao criar projeto:', err);
-      const mensagemErro = Array.isArray(err.response?.data?.message) 
-        ? err.response.data.message[0] 
-        : err.response?.data?.message;
-        
-      setError(mensagemErro || 'Ocorreu um erro ao criar o projeto.');
+    } catch (error) {
+      console.error('Erro ao criar projeto:', error);
+      setErrorMessage(getErrorMessage(error));
     } finally {
-      setLoading(false);
+      setIsLoading(false);
     }
   };
+
+  const inputClass = "w-full rounded-md border border-gray-300 bg-white p-2 text-gray-900 placeholder-gray-400 focus:border-[#195b3d] focus:outline-none focus:ring-1 focus:ring-[#195b3d]";
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
       <div className="w-full max-w-2xl rounded-lg bg-white shadow-xl max-h-[90vh] overflow-y-auto">
-        {/* Cabeçalho */}
         <div className="flex items-center justify-between border-b border-gray-200 p-4 sticky top-0 bg-white z-10 rounded-t-lg">
-          <h2 className="text-xl font-bold text-[#003366]">Criar Novo Projeto</h2>
-          <button
-            onClick={onClose}
-            className="rounded-full p-1 text-gray-500 hover:bg-gray-100 transition-colors"
-          >
+          <h2 className="text-xl font-bold text-[#003366]">{isEditing ? 'Editar Projeto' : 'Criar Novo Projeto'}</h2>
+          <button onClick={onClose} className="rounded-full p-1 text-gray-500 hover:bg-gray-100 transition-colors">
             <X size={24} />
           </button>
         </div>
 
-        {/* Formulário */}
         <form onSubmit={handleSubmit} className="p-6">
-          {error && (
-            <div className="mb-4 rounded bg-red-50 p-3 text-sm text-red-600">
-              {error}
-            </div>
+          {errorMessage && (
+            <div className="mb-4 rounded bg-red-50 p-3 text-sm text-red-600 whitespace-pre-line">{errorMessage}</div>
           )}
 
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <div className="md:col-span-2">
-              <label className="mb-1 block text-sm font-medium text-gray-700">
-                Nome do Projeto *
-              </label>
+              <label className="mb-1 block text-sm font-medium text-gray-700">Nome do Projeto *</label>
               <input
-                type="text"
-                required
-                value={nome}
-                onChange={(e) => setNome(e.target.value)}
-                className="w-full rounded-md border border-gray-300 bg-white p-2 text-gray-900 placeholder-gray-400 focus:border-[#195b3d] focus:outline-none focus:ring-1 focus:ring-[#195b3d]"
-                placeholder="Ex: Sistema de Gerenciamento"
+                type="text" required value={formData.nome}
+                onChange={(e) => setFormData({ ...formData, nome: e.target.value })}
+                className={inputClass} placeholder="Ex: Sistema de Gerenciamento"
               />
             </div>
 
+            {!isEditing && (
+              <div className="md:col-span-2">
+                <label className="mb-1 block text-sm font-medium text-gray-700">Entidade *</label>
+                <select
+                  required value={formData.idEntidade}
+                  onChange={(e) => setFormData({ ...formData, idEntidade: e.target.value })}
+                  className={inputClass}
+                >
+                  <option value="">Selecione uma entidade</option>
+                  {entidades.map((e) => (
+                    <option key={e.id} value={e.id}>{e.nome}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+
             <div className="md:col-span-2">
-              <label className="mb-1 block text-sm font-medium text-gray-700">
-                Descrição
-              </label>
+              <label className="mb-1 block text-sm font-medium text-gray-700">Descrição</label>
               <textarea
-                rows={3}
-                value={descricao}
-                onChange={(e) => setDescricao(e.target.value)}
-                className="w-full rounded-md border border-gray-300 bg-white p-2 text-gray-900 placeholder-gray-400 focus:border-[#195b3d] focus:outline-none focus:ring-1 focus:ring-[#195b3d]"
-                placeholder="Descreva o projeto..."
+                rows={3} value={formData.descricao}
+                onChange={(e) => setFormData({ ...formData, descricao: e.target.value })}
+                className={inputClass} placeholder="Descreva o projeto..."
               />
             </div>
 
             <div className="md:col-span-2">
-              <ImageUploadBox 
-                id="foto-projeto" 
-                label="Capa do Projeto" 
-                file={foto} 
-                onChange={setFoto} 
-                imageClassName="object-cover" 
-              />
-            </div>
-
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
-                Status
-              </label>
+              <label className="mb-1 block text-sm font-medium text-gray-700">Status</label>
               <select
-                value={status}
-                onChange={(e) => setStatus(e.target.value)}
-                className="w-full rounded-md border border-gray-300 bg-white p-2 text-gray-900 focus:border-[#195b3d] focus:outline-none focus:ring-1 focus:ring-[#195b3d]"
+                value={formData.status}
+                onChange={(e) => setFormData({ ...formData, status: e.target.value })}
+                className={inputClass}
               >
-                {StatusProjeto.map((opcao) => (
-                  <option key={opcao.value} value={opcao.value}>
-                    {opcao.label}
-                  </option>
-                ))}
+                <option value="PLANEJAMENTO">Planejamento</option>
+                <option value="EM_ANDAMENTO">Em Andamento</option>
+                <option value="CONCLUIDO">Concluído</option>
+                <option value="CANCELADO">Cancelado</option>
+                <option value="PAUSADO">Pausado</option>
               </select>
             </div>
 
-            <div className="hidden md:block"></div>
-
             <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
-                Data de Início *
-              </label>
+              <label className="mb-1 block text-sm font-medium text-gray-700">Data de Início *</label>
               <input
-                type="date"
-                required
-                value={dataInicio}
-                onChange={(e) => setDataInicio(e.target.value)}
-                className="w-full rounded-md border border-gray-300 bg-white p-2 text-gray-900 focus:border-[#195b3d] focus:outline-none focus:ring-1 focus:ring-[#195b3d]"
+                type="date" required value={formData.dataInicio}
+                onChange={(e) => setFormData({ ...formData, dataInicio: e.target.value })}
+                className={inputClass}
               />
             </div>
-
             <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
-                Data de Fim
-              </label>
+              <label className="mb-1 block text-sm font-medium text-gray-700">Data de Fim</label>
               <input
-                type="date"
-                value={dataFim}
-                onChange={(e) => setDataFim(e.target.value)}
-                className="w-full rounded-md border border-gray-300 bg-white p-2 text-gray-900 focus:border-[#195b3d] focus:outline-none focus:ring-1 focus:ring-[#195b3d]"
+                type="date" value={formData.dataFim}
+                onChange={(e) => setFormData({ ...formData, dataFim: e.target.value })}
+                className={inputClass}
               />
             </div>
           </div>
 
-          <div className="mt-6 flex justify-end gap-3 border-t border-gray-200 pt-4">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 transition-colors"
-              disabled={loading}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2">
+            <ImageUploadBox id="projeto-foto" label="Foto do Projeto" file={pendingFoto} onChange={setPendingFoto} imageClassName="object-cover" />
+            <ImageUploadBox id="projeto-banner" label="Banner do Projeto" file={pendingBanner} onChange={setPendingBanner} imageClassName="object-cover" />
+          </div>
+
+          <div className="flex justify-end gap-3 pt-5 border-t border-gray-100">
+            {isEditing ? (
+              <button type="button" onClick={handleDelete} disabled={isLoading}
+                className="mr-auto inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-red-700 bg-red-50 rounded-md hover:bg-red-100 transition-colors disabled:opacity-50"
+              >
+                <Trash2 size={16} /> Excluir
+              </button>
+            ) : null}
+            <button type="button" onClick={onClose}
+              className="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 transition-colors" disabled={isLoading}
             >
               Cancelar
             </button>
-            <button
-              type="submit"
-              disabled={loading}
+            <button type="submit" disabled={isLoading}
               className="rounded-md bg-[#195b3d] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#12452c] disabled:opacity-50"
             >
-              {loading ? 'Salvando...' : 'Criar Projeto'}
+              {isLoading ? 'Salvando...' : isEditing ? 'Salvar' : 'Criar Projeto'}
             </button>
           </div>
         </form>
@@ -207,3 +255,5 @@ export function CriarProjetoModal({ isOpen, onClose, idEntidade, onSuccess }: Cr
     </div>
   );
 }
+
+export { CreateProjetoModal as CriarProjetoModal };

--- a/apps/front/components/entidade/CreateEntidadeModal.tsx
+++ b/apps/front/components/entidade/CreateEntidadeModal.tsx
@@ -26,12 +26,25 @@ export function CreateEntidadeModal({ isOpen, onClose, onSuccess }: CreateEntida
 
   if (!isOpen) return null;
 
+  const uploadFile = async (file: File, slot: string, entityId: number) => {
+    const fd = new FormData();
+    fd.append('file', file);
+    await api.post(`/entidade/${entityId}/${slot}`, fd, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+      timeout: 30000,
+    });
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
-    
+
     try {
-      await api.post('/entidade', formData);
+      const { data: entidade } = await api.post('/entidade', formData);
+
+      if (logo) await uploadFile(logo, 'logo', entidade.id);
+      if (banner) await uploadFile(banner, 'banner', entidade.id);
+
       toast.success('Entidade criada com sucesso!');
 
       setFormData({
@@ -45,12 +58,12 @@ export function CreateEntidadeModal({ isOpen, onClose, onSuccess }: CreateEntida
       setLogo(null);
 
       onClose();
-      
+
       if (onSuccess) {
         onSuccess();
       } else {
         setTimeout(() => {
-          window.location.reload(); 
+          window.location.reload();
         }, 1500);
       }
     } catch (error) {

--- a/apps/front/components/entidade/EditEntidadeModal.tsx
+++ b/apps/front/components/entidade/EditEntidadeModal.tsx
@@ -3,6 +3,7 @@ import { Trash2, X } from 'lucide-react';
 import { api } from '@/guards/api';
 import { CAMPUS_OPTIONS, ClassificacaoEntidade, DEPARTAMENTO_OPTIONS } from '@/constants/options';
 import { ConfirmModal } from '@/components/ConfirmModal';
+import { ImageUploadBox } from '@/components/ImageUploadBox';
 import { toast } from 'sonner';
 
 type EditEntidadeFormProps = {
@@ -41,7 +42,9 @@ export function EditEntidadeForm({
 }: EditEntidadeFormProps) {
   const [form, setForm] = useState(initialData);
   const [isSaving, setIsSaving] = useState(false);
-  
+  const [pendingLogo, setPendingLogo] = useState<File | null>(null);
+  const [pendingBanner, setPendingBanner] = useState<File | null>(null);
+
   const [isModalDeleteOpen, setIsModalDeleteOpen] = useState(false);
   const [isModalUpdateOpen, setIsModalUpdateOpen] = useState(false);
 
@@ -67,6 +70,18 @@ export function EditEntidadeForm({
         campus: form.campus,
         departamento: form.departamento,
       });
+
+      const upload = async (file: File, slot: string) => {
+        const fd = new FormData();
+        fd.append('file', file);
+        await api.post(`/entidade/${entidadeId}/${slot}`, fd, {
+          headers: { 'Content-Type': 'multipart/form-data' },
+          timeout: 30000,
+        });
+      };
+      if (pendingLogo) await upload(pendingLogo, 'logo');
+      if (pendingBanner) await upload(pendingBanner, 'banner');
+
       toast.success('Mudanças salvas com sucesso!');
       onSuccess();
     } catch (error: unknown) {
@@ -152,6 +167,23 @@ export function EditEntidadeForm({
               {DEPARTAMENTO_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
             </select>
           </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4">
+          <ImageUploadBox
+            id="edit-logo"
+            label="Logo da Entidade"
+            file={pendingLogo}
+            onChange={setPendingLogo}
+            imageClassName="object-contain"
+          />
+          <ImageUploadBox
+            id="edit-banner"
+            label="Banner da Entidade"
+            file={pendingBanner}
+            onChange={setPendingBanner}
+            imageClassName="object-cover"
+          />
         </div>
 
         <div className="flex justify-end mt-4">

--- a/apps/front/lib/upload.ts
+++ b/apps/front/lib/upload.ts
@@ -1,0 +1,50 @@
+import { api } from "@/guards/api";
+
+export type StorageSlot =
+  | "avatar"
+  | "logo"
+  | "banner"
+  | "postagem"
+  | "projeto_foto"
+  | "projeto_banner"
+  | "processo_foto";
+
+export interface UploadImageResult {
+  fileId: string;
+  key: string;
+  url: string;
+  size: number;
+  mimeType: string;
+}
+
+/**
+ * Envia uma imagem para o backend (que comprime com sharp e grava no R2/local).
+ * Retorna a URL pública já pronta para uso em payloads de criação/edição.
+ *
+ * Fluxo recomendado:
+ *   1. Usuário escolhe arquivo (ImageUploadBox).
+ *   2. Antes de salvar a entidade, chame uploadImage() e use a URL retornada.
+ *   3. Envie o payload JSON normal com a URL preenchida.
+ */
+export async function uploadImage(
+  file: File,
+  slot: StorageSlot,
+  entityId?: number,
+): Promise<UploadImageResult> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const params = new URLSearchParams({ slot });
+  if (entityId != null) params.set("entityId", String(entityId));
+
+  const { data } = await api.post<UploadImageResult>(
+    `/storage/upload?${params.toString()}`,
+    formData,
+    {
+      headers: { "Content-Type": "multipart/form-data" },
+      timeout: 30000,
+    },
+  );
+
+  return data;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      sharp:
+        specifier: ^0.35.2
+        version: 0.35.2
       winston:
         specifier: ^3.9.0
         version: 3.19.0
@@ -629,6 +632,9 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
@@ -856,14 +862,36 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-darwin-arm64@0.35.2':
+    resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-x64@0.34.5':
     resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-darwin-x64@0.35.2':
+    resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.2':
+    resolution: {integrity: sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
     cpu: [arm64]
     os: [darwin]
 
@@ -872,8 +900,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    resolution: {integrity: sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -884,8 +923,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -896,8 +947,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -908,14 +971,32 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -927,9 +1008,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-arm64@0.35.2':
+    resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.2':
+    resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -941,9 +1036,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-ppc64@0.35.2':
+    resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -955,9 +1064,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-s390x@0.35.2':
+    resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.2':
+    resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -969,9 +1092,23 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -981,9 +1118,24 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
+  '@img/sharp-wasm32@0.35.2':
+    resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.2':
+    resolution: {integrity: sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
   '@img/sharp-win32-arm64@0.34.5':
     resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-arm64@0.35.2':
+    resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
@@ -993,9 +1145,21 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.35.2':
+    resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.34.5':
     resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.2':
+    resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -4841,6 +5005,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -4870,6 +5039,10 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  sharp@0.35.2:
+    resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
+    engines: {node: '>=20.9.0'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -6217,6 +6390,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
@@ -6362,12 +6540,16 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
     optional: true
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -6375,34 +6557,74 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
+  '@img/sharp-darwin-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
     optional: true
 
   '@img/sharp-linux-arm64@0.34.5':
@@ -6410,9 +6632,19 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+    optional: true
+
   '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.1
     optional: true
 
   '@img/sharp-linux-ppc64@0.34.5':
@@ -6420,9 +6652,19 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-ppc64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+    optional: true
+
   '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
     optional: true
 
   '@img/sharp-linux-s390x@0.34.5':
@@ -6430,9 +6672,19 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
+  '@img/sharp-linux-s390x@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+    optional: true
+
   '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.1
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
@@ -6440,9 +6692,19 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -6450,13 +6712,32 @@ snapshots:
       '@emnapi/runtime': 1.10.0
     optional: true
 
+  '@img/sharp-wasm32@0.35.2':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
+    optional: true
+
   '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.2':
     optional: true
 
   '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
+  '@img/sharp-win32-ia32@0.35.2':
+    optional: true
+
   '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.2':
     optional: true
 
   '@inquirer/ansi@1.0.2': {}
@@ -10782,6 +11063,8 @@ snapshots:
 
   semver@7.8.1: {}
 
+  semver@7.8.5: {}
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -10864,6 +11147,38 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
     optional: true
+
+  sharp@0.35.2:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.2
+      '@img/sharp-darwin-x64': 0.35.2
+      '@img/sharp-freebsd-wasm32': 0.35.2
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+      '@img/sharp-libvips-linux-arm': 1.3.1
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+      '@img/sharp-libvips-linux-x64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+      '@img/sharp-linux-arm': 0.35.2
+      '@img/sharp-linux-arm64': 0.35.2
+      '@img/sharp-linux-ppc64': 0.35.2
+      '@img/sharp-linux-riscv64': 0.35.2
+      '@img/sharp-linux-s390x': 0.35.2
+      '@img/sharp-linux-x64': 0.35.2
+      '@img/sharp-linuxmusl-arm64': 0.35.2
+      '@img/sharp-linuxmusl-x64': 0.35.2
+      '@img/sharp-webcontainers-wasm32': 0.35.2
+      '@img/sharp-win32-arm64': 0.35.2
+      '@img/sharp-win32-ia32': 0.35.2
+      '@img/sharp-win32-x64': 0.35.2
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
### Descrição

Adiciona campo de busca de entidades na página de gestão e endpoints para seguir/desseguir entidades.

### Mudanças

**Backend:**
- `GET /entidade/buscar?q=...` — busca entidades por nome (case-insensitive)
- `POST /entidade/:id/seguir` — seguir entidade
- `DELETE /entidade/:id/seguir` — desseguir entidade

**Frontend:**
- Campo de busca na página `/conecta/entidades/gestao` ao lado do botão "Criar Entidade"
- Dropdown com resultados contendo logo, nome, classificação e botão "Seguir"
- Debounce de 300ms na busca

close #121 