### PR TITLE
fix(ui): feed de publicações, busca de processos seletivos e correções de perfil/membros

### DIFF
--- a/apps/back/src/entidade/entidade.service.spec.ts
+++ b/apps/back/src/entidade/entidade.service.spec.ts
@@ -150,6 +150,7 @@ describe('EntidadeService', () => {
         membros: {
           select: {
             id: true,
+            idPerfil: true,
             classificacao: true,
             perfil: {
               select: { id: true, name: true, email: true, linkFoto: true },

--- a/apps/back/src/entidade/entidade.service.ts
+++ b/apps/back/src/entidade/entidade.service.ts
@@ -69,6 +69,7 @@ export class EntidadeService {
         membros: {
           select: {
             id: true,
+            idPerfil: true,
             classificacao: true,
             perfil: {
               select: { id: true, name: true, email: true, linkFoto: true },

--- a/apps/back/src/perfil/dto/update-perfil.dto.ts
+++ b/apps/back/src/perfil/dto/update-perfil.dto.ts
@@ -1,12 +1,12 @@
 import { OmitType, PartialType, ApiProperty } from '@nestjs/swagger';
 import { CreatePerfilDto } from '../../auth/dto/register.dto';
-import { IsOptional, IsUrl } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class UpdatePerfilDto extends PartialType(
   OmitType(CreatePerfilDto, ['senha'] as const),
 ) {
   @ApiProperty({ description: 'URL da foto de perfil', required: false })
   @IsOptional()
-  @IsUrl({}, { message: 'O link da foto deve ser uma URL válida.' })
+  @IsString()
   linkFoto?: string;
 }

--- a/apps/front/app/conecta/entidades/gestao/page.tsx
+++ b/apps/front/app/conecta/entidades/gestao/page.tsx
@@ -7,6 +7,8 @@ import { ProjetoCard } from '@/components/entidade/projetoCard';
 import { CreateEntidadeModal } from '@/components/entidade/CreateEntidadeModal';
 import { ManageMembersModal } from '@/components/entidade/ManageMembersModal';
 import { EditEntidadeModal } from '@/components/entidade/EditEntidadeModal';
+import { ProcessoSeletivoViewModal } from '@/components/ProcessoSeletivoViewModal';
+import { type ProcessoSeletivo } from '@/components/ProcessoSeletivoFormModal';
 import { api } from '@/guards/api';
 
 type VinculoEntidade = {
@@ -38,29 +40,30 @@ export default function EntidadesPage() {
   const router = useRouter();
 
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-  
+
   const [entidadeToEdit, setEntidadeToEdit] = useState<EntidadeResumo | null>(null);
   const [entidadeToManageMembers, setEntidadeToManageMembers] = useState<EntidadeResumo | null>(null);
-  
+
   const [minhasEntidades, setMinhasEntidades] = useState<EntidadeResumo[]>([]);
   const [entidadesCogestao, setEntidadesCogestao] = useState<EntidadeResumo[]>([]);
   const [entidadesMembro, setEntidadesMembro] = useState<EntidadeResumo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState<EntidadeBusca[]>([]);
-  const [isSearching, setIsSearching] = useState(false);
-  const [showResults, setShowResults] = useState(false);
-  const [followingIds, setFollowingIds] = useState<Set<number>>(new Set());
+  const [processosAbertos, setProcessosAbertos] = useState<ProcessoSeletivo[]>([]);
+  const [psSearchQuery, setPsSearchQuery] = useState('');
+  const [psSearchResults, setPsSearchResults] = useState<EntidadeBusca[]>([]);
+  const [psIsSearching, setPsIsSearching] = useState(false);
+  const [psShowResults, setPsShowResults] = useState(false);
+  const [processoSelecionado, setProcessoSelecionado] = useState<ProcessoSeletivo | null>(null);
 
-  const searchRef = useRef<HTMLDivElement>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const psSearchRef = useRef<HTMLDivElement>(null);
+  const psDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const fetchEntidades = useCallback(async () => {
     try {
       const response = await api.get('/entidade/minhas');
       const entidades = response.data;
-      
+
       setMinhasEntidades(entidades.filter((e: EntidadeResumo) => e.vinculo.classificacao === 'GESTOR'));
       setEntidadesCogestao(entidades.filter((e: EntidadeResumo) => e.vinculo.classificacao === 'CO_GESTOR'));
       setEntidadesMembro(entidades.filter((e: EntidadeResumo) => e.vinculo.classificacao === 'MEMBRO'));
@@ -71,49 +74,59 @@ export default function EntidadesPage() {
     }
   }, []);
 
-  useEffect(() => {
-    fetchEntidades();
-  }, [fetchEntidades]);
+  const fetchProcessosAbertos = useCallback(async () => {
+    try {
+      const response = await api.get<ProcessoSeletivo[]>('/processo-seletivo');
+      const agora = new Date();
+      const abertos = response.data.filter(
+        (p) => p.classificacao === 'ABERTA' && new Date(p.fimInscricao as string) >= agora,
+      );
+      setProcessosAbertos(abertos);
+    } catch (error) {
+      console.error('Erro ao buscar processos seletivos:', error);
+    }
+  }, []);
 
   useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    if (!searchQuery.trim()) {
-      setSearchResults([]);
-      setShowResults(false);
+    fetchEntidades();
+    fetchProcessosAbertos();
+  }, [fetchEntidades, fetchProcessosAbertos]);
+
+  useEffect(() => {
+    if (psDebounceRef.current) clearTimeout(psDebounceRef.current);
+    if (!psSearchQuery.trim()) {
+      setPsSearchResults([]);
+      setPsShowResults(false);
       return;
     }
-    debounceRef.current = setTimeout(async () => {
-      setIsSearching(true);
+    psDebounceRef.current = setTimeout(async () => {
+      setPsIsSearching(true);
       try {
-        const res = await api.get('/entidade/buscar', { params: { q: searchQuery } });
-        setSearchResults(res.data);
-        setShowResults(true);
+        const res = await api.get<EntidadeBusca[]>('/entidade/buscar', {
+          params: { q: psSearchQuery },
+        });
+        const comProcessos = res.data.filter((entidade) =>
+          processosAbertos.some((p) => p.idEntidade === entidade.id),
+        );
+        setPsSearchResults(comProcessos);
+        setPsShowResults(true);
       } catch {
-        setSearchResults([]);
+        setPsSearchResults([]);
       } finally {
-        setIsSearching(false);
+        setPsIsSearching(false);
       }
     }, 300);
-  }, [searchQuery]);
+  }, [psSearchQuery, processosAbertos]);
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
-      if (searchRef.current && !searchRef.current.contains(e.target as Node)) {
-        setShowResults(false);
+      if (psSearchRef.current && !psSearchRef.current.contains(e.target as Node)) {
+        setPsShowResults(false);
       }
     }
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
-
-  const handleSeguir = async (id: number) => {
-    try {
-      await api.post(`/entidade/${id}/seguir`);
-      setFollowingIds((prev) => new Set(prev).add(id));
-    } catch {
-      console.error('Erro ao seguir entidade');
-    }
-  };
 
   const classLabel = (c: string) =>
     c.replaceAll('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase());
@@ -122,7 +135,7 @@ export default function EntidadesPage() {
     <div className="flex min-h-screen bg-[#fafafa]">
       <main className="flex-1 p-12">
         <div className="flex justify-between items-center mb-12 gap-4">
-          <div ref={searchRef} className="relative flex-1 max-w-md">
+          <div ref={psSearchRef} className="relative flex-1 max-w-md">
             <div className="relative">
               <Search
                 size={18}
@@ -130,73 +143,72 @@ export default function EntidadesPage() {
               />
               <input
                 type="text"
-                placeholder="Buscar entidades..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                onFocus={() => { if (searchResults.length > 0) setShowResults(true); }}
+                placeholder="Buscar processos seletivos por entidade..."
+                value={psSearchQuery}
+                onChange={(e) => setPsSearchQuery(e.target.value)}
+                onFocus={() => { if (psSearchResults.length > 0) setPsShowResults(true); }}
                 className="w-full pl-10 pr-4 py-3 rounded-md border border-gray-300 bg-white text-[#0d2a54] placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#195b3d] focus:border-transparent text-sm"
               />
-              {isSearching && (
+              {psIsSearching && (
                 <div className="absolute right-3 top-1/2 -translate-y-1/2">
                   <div className="w-4 h-4 border-2 border-[#195b3d] border-t-transparent rounded-full animate-spin" />
                 </div>
               )}
             </div>
-            {showResults && (
-              <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-gray-200 rounded-xl shadow-lg z-50 max-h-80 overflow-y-auto">
-                {searchResults.length > 0 ? (
-                  searchResults.map((entidade) => (
-                    <div
-                      key={entidade.id}
-                      className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 border-b border-gray-100 last:border-b-0"
-                    >
+            {psShowResults && (
+              <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-gray-200 rounded-xl shadow-lg z-50 max-h-96 overflow-y-auto">
+                {psSearchResults.length > 0 ? (
+                  psSearchResults.map((entidade) => {
+                    const processosDaEntidade = processosAbertos.filter(
+                      (p) => p.idEntidade === entidade.id,
+                    );
+                    return (
                       <div
-                        className="flex-1 flex items-center gap-3 min-w-0 cursor-pointer"
-                        onClick={() => {
-                          setShowResults(false);
-                          router.push(`/conecta/entidades/${entidade.id}`);
-                        }}
+                        key={entidade.id}
+                        className="px-4 py-3 hover:bg-gray-50 border-b border-gray-100 last:border-b-0"
                       >
-                        {entidade.linkLogo ? (
-                          <img
-                            src={entidade.linkLogo}
-                            alt={entidade.nome}
-                            className="w-10 h-10 rounded-full object-cover flex-shrink-0"
-                          />
-                        ) : (
-                          <div className="w-10 h-10 rounded-full bg-gray-200 flex-shrink-0 flex items-center justify-center text-gray-400">
-                            <User size={20} />
+                        <div className="flex items-center gap-3 mb-2">
+                          {entidade.linkLogo ? (
+                            <img
+                              src={entidade.linkLogo}
+                              alt={entidade.nome}
+                              className="w-10 h-10 rounded-full object-cover flex-shrink-0"
+                            />
+                          ) : (
+                            <div className="w-10 h-10 rounded-full bg-gray-200 flex-shrink-0 flex items-center justify-center text-gray-400">
+                              <User size={20} />
+                            </div>
+                          )}
+                          <div className="min-w-0">
+                            <p className="font-medium text-[#0d2a54] text-sm truncate">
+                              {entidade.nome}
+                            </p>
+                            <p className="text-xs text-gray-500 truncate">
+                              {classLabel(entidade.classificacao)} &middot; {entidade.campus}
+                            </p>
                           </div>
-                        )}
-                        <div className="min-w-0">
-                          <p className="font-medium text-[#0d2a54] text-sm truncate">
-                            {entidade.nome}
-                          </p>
-                          <p className="text-xs text-gray-500 truncate">
-                            {classLabel(entidade.classificacao)} &middot; {entidade.campus}
-                          </p>
+                        </div>
+                        <div className="flex flex-col gap-1 pl-[3.25rem]">
+                          {processosDaEntidade.map((processo) => (
+                            <button
+                              key={processo.id}
+                              type="button"
+                              onClick={() => {
+                                setProcessoSelecionado(processo);
+                                setPsShowResults(false);
+                              }}
+                              className="text-left text-sm text-[#195b3d] font-medium hover:underline truncate"
+                            >
+                              {processo.titulo}
+                            </button>
+                          ))}
                         </div>
                       </div>
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleSeguir(entidade.id);
-                        }}
-                        disabled={followingIds.has(entidade.id)}
-                        className={`flex-shrink-0 px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
-                          followingIds.has(entidade.id)
-                            ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-                            : 'bg-[#195b3d] text-white hover:bg-[#13472f]'
-                        }`}
-                      >
-                        {followingIds.has(entidade.id) ? 'Seguindo' : 'Seguir'}
-                      </button>
-                    </div>
-                  ))
+                    );
+                  })
                 ) : (
                   <p className="px-4 py-6 text-center text-sm text-gray-500">
-                    Nenhuma entidade encontrada.
+                    Nenhum processo seletivo aberto encontrado.
                   </p>
                 )}
               </div>
@@ -270,9 +282,9 @@ export default function EntidadesPage() {
         </section>
       </main>
 
-      <CreateEntidadeModal 
-        isOpen={isCreateModalOpen} 
-        onClose={() => setIsCreateModalOpen(false)} 
+      <CreateEntidadeModal
+        isOpen={isCreateModalOpen}
+        onClose={() => setIsCreateModalOpen(false)}
         onSuccess={fetchEntidades}
       />
 
@@ -288,6 +300,12 @@ export default function EntidadesPage() {
         entidade={entidadeToManageMembers}
         onClose={() => setEntidadeToManageMembers(null)}
         onChanged={fetchEntidades}
+      />
+
+      <ProcessoSeletivoViewModal
+        isOpen={!!processoSelecionado}
+        onClose={() => setProcessoSelecionado(null)}
+        processo={processoSelecionado}
       />
     </div>
   );

--- a/apps/front/app/conecta/feed/page.tsx
+++ b/apps/front/app/conecta/feed/page.tsx
@@ -192,18 +192,6 @@ export default function HomePage() {
     );
   }
 
-  if (!user) {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center space-y-4 bg-gray-50 text-[#1D1D1D]">
-        <h1 className="text-2xl text-red-600 font-bold">Não Logado</h1>
-        <p>Faça o Login - FEED</p>
-        <a href="/auth/login" className="px-4 py-2 bg-[#003366] text-white rounded-full">
-          Ir para o Login
-        </a>
-      </div>
-    );
-  }
-
   return (
     <div className="p-8 bg-gray-50 text-[#1D1D1D]">
       <div className="max-w-4xl mx-auto">
@@ -327,21 +315,23 @@ export default function HomePage() {
                           </p>
                         </div>
                       </div>
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleSeguir(entidade.id);
-                        }}
-                        disabled={followingIds.has(entidade.id)}
-                        className={`flex-shrink-0 px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
-                          followingIds.has(entidade.id)
-                            ? "bg-gray-100 text-gray-400 cursor-not-allowed"
-                            : "bg-[#195b3d] text-white hover:bg-[#13472f]"
-                        }`}
-                      >
-                        {followingIds.has(entidade.id) ? "Seguindo" : "Seguir"}
-                      </button>
+                      {user && (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleSeguir(entidade.id);
+                          }}
+                          disabled={followingIds.has(entidade.id)}
+                          className={`flex-shrink-0 px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                            followingIds.has(entidade.id)
+                              ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                              : "bg-[#195b3d] text-white hover:bg-[#13472f]"
+                          }`}
+                        >
+                          {followingIds.has(entidade.id) ? "Seguindo" : "Seguir"}
+                        </button>
+                      )}
                     </div>
                   ))
                 ) : (

--- a/apps/front/app/conecta/feed/page.tsx
+++ b/apps/front/app/conecta/feed/page.tsx
@@ -207,8 +207,8 @@ export default function HomePage() {
   return (
     <div className="p-8 bg-gray-50 text-[#1D1D1D]">
       <div className="max-w-4xl mx-auto">
-        {/* Barra superior: filtros (esquerda) + buscar entidades (direita) */}
-        <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+        {/* Barra superior: filtros + buscar entidades à direita deles */}
+        <div className="mb-8 flex flex-wrap items-center gap-4">
           {/* Filtros compactos */}
           <div className="flex flex-wrap items-center gap-2">
             <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-[#0d2a54]">
@@ -269,7 +269,7 @@ export default function HomePage() {
           </div>
 
           {/* Buscar entidades */}
-          <div ref={searchRef} className="relative w-full max-w-sm">
+          <div ref={searchRef} className="relative w-56">
             <div className="relative">
               <Search
                 size={18}

--- a/apps/front/app/conecta/feed/page.tsx
+++ b/apps/front/app/conecta/feed/page.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { SlidersHorizontal, X } from "lucide-react";
+import { Search, SlidersHorizontal, User, X } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import { api } from "@/guards/api";
-import { CAMPUS_OPTIONS, DEPARTAMENTO_OPTIONS, ClassificacaoEntidade } from "@/constants/options";
-import { ProjetoCard } from "@/components/entidade/projetoCard";
+import {
+  CAMPUS_OPTIONS,
+  DEPARTAMENTO_OPTIONS,
+  ClassificacaoEntidade,
+} from "@/constants/options";
+import { PostagemCardFeed } from "@/components/PostagemCardFeed";
+import { PostagemModal, type PostagemDetalhe } from "@/components/PostagemModal";
 
 type EntidadeResumo = {
   id: number;
@@ -16,6 +21,23 @@ type EntidadeResumo = {
   campus?: string;
   departamento?: string;
   linkLogo?: string | null;
+};
+
+type EntidadeBusca = {
+  id: number;
+  nome: string;
+  classificacao: string;
+  campus: string;
+  linkLogo: string | null;
+};
+
+type Postagem = {
+  id: number;
+  idEntidade: number;
+  titulo: string;
+  conteudo: string;
+  linkFoto?: string | null;
+  createdAt?: string;
 };
 
 type Filtros = {
@@ -28,6 +50,7 @@ export default function HomePage() {
   const { user, loading } = useAuth();
   const router = useRouter();
 
+  const [postagens, setPostagens] = useState<Postagem[]>([]);
   const [entidades, setEntidades] = useState<EntidadeResumo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [filtros, setFiltros] = useState<Filtros>({
@@ -36,41 +59,78 @@ export default function HomePage() {
     classificacao: "",
   });
 
-  const fetchEntidades = useCallback(async () => {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<EntidadeBusca[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [showResults, setShowResults] = useState(false);
+  const [followingIds, setFollowingIds] = useState<Set<number>>(new Set());
+  const searchRef = useRef<HTMLDivElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const [postagemSelecionada, setPostagemSelecionada] =
+    useState<PostagemDetalhe | null>(null);
+
+  const fetchDados = useCallback(async () => {
     setIsLoading(true);
     try {
-      const response = await api.get("/entidade");
-      setEntidades(response.data);
+      const [postagensRes, entidadesRes] = await Promise.all([
+        api.get<Postagem[]>("/postagem"),
+        api.get<EntidadeResumo[]>("/entidade"),
+      ]);
+      setPostagens(postagensRes.data);
+      setEntidades(entidadesRes.data);
     } catch (error) {
-      console.error("Erro ao buscar entidades:", error);
+      console.error("Erro ao buscar dados do feed:", error);
     } finally {
       setIsLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    fetchEntidades();
-  }, [fetchEntidades]);
+    fetchDados();
+  }, [fetchDados]);
 
-  const entidadesFiltradas = useMemo(() => {
-    return entidades.filter((entidade) => {
-      if (filtros.campus && entidade.campus !== filtros.campus) return false;
-      if (filtros.departamento && entidade.departamento !== filtros.departamento)
-        return false;
-      if (filtros.classificacao && entidade.classificacao !== filtros.classificacao)
-        return false;
-      return true;
-    });
-  }, [entidades, filtros]);
+  const entidadesMap = useMemo(() => {
+    const map = new Map<number, EntidadeResumo>();
+    entidades.forEach((e) => map.set(e.id, e));
+    return map;
+  }, [entidades]);
+
+  const postagensFiltradas = useMemo<PostagemDetalhe[]>(() => {
+    return postagens
+      .map((postagem): PostagemDetalhe => {
+        const entidade = entidadesMap.get(postagem.idEntidade);
+        return {
+          id: postagem.id,
+          idEntidade: postagem.idEntidade,
+          titulo: postagem.titulo,
+          conteudo: postagem.conteudo,
+          linkFoto: postagem.linkFoto ?? null,
+          dataPublicacao: postagem.createdAt
+            ? new Date(postagem.createdAt).toLocaleDateString("pt-BR")
+            : undefined,
+          entidadeNome: entidade?.nome ?? "Entidade",
+          entidadeLogo: entidade?.linkLogo ?? null,
+        };
+      })
+      .filter((postagem) => {
+        const entidade = entidadesMap.get(postagem.idEntidade);
+        if (!entidade) return false;
+        if (filtros.campus && entidade.campus !== filtros.campus) return false;
+        if (filtros.departamento && entidade.departamento !== filtros.departamento)
+          return false;
+        if (filtros.classificacao && entidade.classificacao !== filtros.classificacao)
+          return false;
+        return true;
+      });
+  }, [postagens, entidadesMap, filtros]);
 
   const filtrosAtivos =
     Boolean(filtros.campus) ||
     Boolean(filtros.departamento) ||
     Boolean(filtros.classificacao);
 
-  const handleFiltroChange = (
-    event: React.ChangeEvent<HTMLSelectElement>,
-  ) => {
+  const handleFiltroChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const { name, value } = event.target;
     setFiltros((prev) => ({ ...prev, [name]: value }));
   };
@@ -78,6 +138,51 @@ export default function HomePage() {
   const limparFiltros = () => {
     setFiltros({ campus: "", departamento: "", classificacao: "" });
   };
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!searchQuery.trim()) {
+      setSearchResults([]);
+      setShowResults(false);
+      return;
+    }
+    debounceRef.current = setTimeout(async () => {
+      setIsSearching(true);
+      try {
+        const res = await api.get("/entidade/buscar", {
+          params: { q: searchQuery },
+        });
+        setSearchResults(res.data);
+        setShowResults(true);
+      } catch {
+        setSearchResults([]);
+      } finally {
+        setIsSearching(false);
+      }
+    }, 300);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (searchRef.current && !searchRef.current.contains(e.target as Node)) {
+        setShowResults(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSeguir = async (id: number) => {
+    try {
+      await api.post(`/entidade/${id}/seguir`);
+      setFollowingIds((prev) => new Set(prev).add(id));
+    } catch {
+      console.error("Erro ao seguir entidade");
+    }
+  };
+
+  const classLabel = (c: string) =>
+    c.replaceAll("_", " ").replace(/\b\w/g, (l) => l.toUpperCase());
 
   if (loading) {
     return (
@@ -102,100 +207,182 @@ export default function HomePage() {
   return (
     <div className="p-8 bg-gray-50 text-[#1D1D1D]">
       <div className="max-w-4xl mx-auto">
-
-          {/* Barra de filtros */}
-          <div className="mb-8 flex flex-wrap items-end gap-x-5 gap-y-3 bg-white border border-gray-200 rounded-xl shadow-sm px-5 py-4">
-            <span className="inline-flex items-center gap-2 text-sm font-semibold text-[#0d2a54] pr-3 border-r border-gray-200 self-center">
-              <SlidersHorizontal size={18} /> Filtros
+        {/* Barra superior: filtros (esquerda) + buscar entidades (direita) */}
+        <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+          {/* Filtros compactos */}
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-[#0d2a54]">
+              <SlidersHorizontal size={16} /> Filtros
             </span>
 
-            <label className="flex flex-col gap-1">
-              <span className="text-xs font-medium text-gray-600">Campus</span>
-              <select
-                name="campus"
-                value={filtros.campus}
-                onChange={handleFiltroChange}
-                className="min-w-[10rem] px-3 py-2 border border-gray-300 rounded-md focus:ring-[#195b3d] focus:border-[#195b3d] outline-none bg-white text-black text-sm"
-              >
-                <option value="">Todos</option>
-                {CAMPUS_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <select
+              name="campus"
+              value={filtros.campus}
+              onChange={handleFiltroChange}
+              className="min-w-[7rem] px-2.5 py-2 rounded-md border border-gray-300 bg-white text-black text-sm focus:ring-2 focus:ring-[#195b3d] focus:border-transparent outline-none"
+            >
+              <option value="">Campus</option>
+              {CAMPUS_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
 
-            <label className="flex flex-col gap-1">
-              <span className="text-xs font-medium text-gray-600">Departamento</span>
-              <select
-                name="departamento"
-                value={filtros.departamento}
-                onChange={handleFiltroChange}
-                className="min-w-[10rem] px-3 py-2 border border-gray-300 rounded-md focus:ring-[#195b3d] focus:border-[#195b3d] outline-none bg-white text-black text-sm"
-              >
-                <option value="">Todos</option>
-                {DEPARTAMENTO_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <select
+              name="departamento"
+              value={filtros.departamento}
+              onChange={handleFiltroChange}
+              className="min-w-[8rem] px-2.5 py-2 rounded-md border border-gray-300 bg-white text-black text-sm focus:ring-2 focus:ring-[#195b3d] focus:border-transparent outline-none"
+            >
+              <option value="">Departamento</option>
+              {DEPARTAMENTO_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
 
-            <label className="flex flex-col gap-1">
-              <span className="text-xs font-medium text-gray-600">Tipos</span>
-              <select
-                name="classificacao"
-                value={filtros.classificacao}
-                onChange={handleFiltroChange}
-                className="min-w-[12rem] px-3 py-2 border border-gray-300 rounded-md focus:ring-[#195b3d] focus:border-[#195b3d] outline-none bg-white text-black text-sm"
-              >
-                <option value="">Todos</option>
-                {ClassificacaoEntidade.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <select
+              name="classificacao"
+              value={filtros.classificacao}
+              onChange={handleFiltroChange}
+              className="min-w-[8rem] px-2.5 py-2 rounded-md border border-gray-300 bg-white text-black text-sm focus:ring-2 focus:ring-[#195b3d] focus:border-transparent outline-none"
+            >
+              <option value="">Tipos</option>
+              {ClassificacaoEntidade.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
 
             {filtrosAtivos ? (
               <button
                 type="button"
                 onClick={limparFiltros}
-                className="ml-auto inline-flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+                className="inline-flex items-center gap-1 px-2.5 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
               >
-                <X size={16} /> Limpar
+                <X size={14} /> Limpar
               </button>
             ) : null}
           </div>
 
-          {/* Entidades */}
-          <section className="mt-8">
-            <h2 className="text-2xl font-bold text-[#0d2a54] mb-6 border-b-2 border-[#195b3d] pb-2">
-              Entidades
-            </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-              {isLoading ? (
-                <p className="text-gray-500">Carregando...</p>
-              ) : entidadesFiltradas.length > 0 ? (
-                entidadesFiltradas.map((entidade) => (
-                  <ProjetoCard
-                    key={entidade.id}
-                    nome={entidade.nome}
-                    descricao={entidade.descricao ?? ""}
-                    imagem={entidade.linkLogo || undefined}
-                    onClick={() => router.push(`/conecta/entidades/${entidade.id}`)}
-                    vinculo="MEMBRO"
-                  />
-                ))
-              ) : (
-                <p className="text-gray-500">Nenhuma entidade encontrada para os filtros.</p>
+          {/* Buscar entidades */}
+          <div ref={searchRef} className="relative w-full max-w-sm">
+            <div className="relative">
+              <Search
+                size={18}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
+              />
+              <input
+                type="text"
+                placeholder="Buscar entidades..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onFocus={() => {
+                  if (searchResults.length > 0) setShowResults(true);
+                }}
+                className="w-full pl-10 pr-4 py-2.5 rounded-md border border-gray-300 bg-white text-[#0d2a54] placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#195b3d] focus:border-transparent text-sm"
+              />
+              {isSearching && (
+                <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                  <div className="w-4 h-4 border-2 border-[#195b3d] border-t-transparent rounded-full animate-spin" />
+                </div>
               )}
             </div>
-          </section>
+            {showResults && (
+              <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-gray-200 rounded-xl shadow-lg z-50 max-h-80 overflow-y-auto">
+                {searchResults.length > 0 ? (
+                  searchResults.map((entidade) => (
+                    <div
+                      key={entidade.id}
+                      className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 border-b border-gray-100 last:border-b-0"
+                    >
+                      <div
+                        className="flex-1 flex items-center gap-3 min-w-0 cursor-pointer"
+                        onClick={() => {
+                          setShowResults(false);
+                          router.push(`/conecta/entidades/${entidade.id}`);
+                        }}
+                      >
+                        {entidade.linkLogo ? (
+                          <img
+                            src={entidade.linkLogo}
+                            alt={entidade.nome}
+                            className="w-10 h-10 rounded-full object-cover flex-shrink-0"
+                          />
+                        ) : (
+                          <div className="w-10 h-10 rounded-full bg-gray-200 flex-shrink-0 flex items-center justify-center text-gray-400">
+                            <User size={20} />
+                          </div>
+                        )}
+                        <div className="min-w-0">
+                          <p className="font-medium text-[#0d2a54] text-sm truncate">
+                            {entidade.nome}
+                          </p>
+                          <p className="text-xs text-gray-500 truncate">
+                            {classLabel(entidade.classificacao)} &middot;{" "}
+                            {entidade.campus}
+                          </p>
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleSeguir(entidade.id);
+                        }}
+                        disabled={followingIds.has(entidade.id)}
+                        className={`flex-shrink-0 px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                          followingIds.has(entidade.id)
+                            ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                            : "bg-[#195b3d] text-white hover:bg-[#13472f]"
+                        }`}
+                      >
+                        {followingIds.has(entidade.id) ? "Seguindo" : "Seguir"}
+                      </button>
+                    </div>
+                  ))
+                ) : (
+                  <p className="px-4 py-6 text-center text-sm text-gray-500">
+                    Nenhuma entidade encontrada.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
         </div>
+
+        {/* Publicações */}
+        <section>
+          <div className="flex flex-col gap-4">
+            {isLoading ? (
+              <p className="text-gray-500">Carregando publicações...</p>
+            ) : postagensFiltradas.length > 0 ? (
+              postagensFiltradas.map((postagem) => (
+                <PostagemCardFeed
+                  key={postagem.id}
+                  postagem={postagem}
+                  vinculo={null}
+                  onClick={() => setPostagemSelecionada(postagem)}
+                />
+              ))
+            ) : (
+              <p className="text-gray-500">
+                Nenhuma publicação encontrada para os filtros.
+              </p>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <PostagemModal
+        isOpen={!!postagemSelecionada}
+        onClose={() => setPostagemSelecionada(null)}
+        postagem={postagemSelecionada}
+        vinculo={null}
+      />
     </div>
   );
 }

--- a/apps/front/app/conecta/perfil/[id]/page.tsx
+++ b/apps/front/app/conecta/perfil/[id]/page.tsx
@@ -40,6 +40,7 @@ export default function PerfilPage() {
     campus: "",
     curso: "",
     departamento: "",
+    cargo: "" as string,
     linkFoto: "" as string | null | undefined,
   });
 
@@ -94,6 +95,7 @@ export default function PerfilPage() {
         campus: formData.campus,
         curso: formData.curso,
         departamento: formData.departamento,
+        cargo: formData.cargo,
         linkFoto,
       };
       await api.patch(`/perfil`, payload);

--- a/apps/front/app/conecta/perfil/[id]/page.tsx
+++ b/apps/front/app/conecta/perfil/[id]/page.tsx
@@ -90,6 +90,7 @@ export default function PerfilPage() {
       const payload = {
         name: formData.name,
         matricula: formData.matricula,
+        email: formData.email,
         campus: formData.campus,
         curso: formData.curso,
         departamento: formData.departamento,

--- a/apps/front/lib/upload.ts
+++ b/apps/front/lib/upload.ts
@@ -37,14 +37,53 @@ export async function uploadImage(
   const params = new URLSearchParams({ slot });
   if (entityId != null) params.set("entityId", String(entityId));
 
-  const { data } = await api.post<UploadImageResult>(
-    `/storage/upload?${params.toString()}`,
-    formData,
-    {
-      headers: { "Content-Type": "multipart/form-data" },
-      timeout: 30000,
-    },
-  );
+  try {
+    const { data } = await api.post<UploadImageResult>(
+      `/storage/upload?${params.toString()}`,
+      formData,
+      {
+        headers: { "Content-Type": "multipart/form-data" },
+        timeout: 30000,
+      },
+    );
 
-  return data;
+    return data;
+  } catch (error) {
+    const status = (error as { response?: { status?: number } }).response?.status;
+
+    if (slot === "avatar" && status === 404) {
+      const localFormData = new FormData();
+      localFormData.append("file", file);
+      if (entityId != null) localFormData.append("entityId", String(entityId));
+
+      const localResponse = await fetch("/api/uploads/avatar", {
+        method: "POST",
+        body: localFormData,
+      });
+
+      if (!localResponse.ok) {
+        throw error;
+      }
+
+      const data = (await localResponse.json()) as {
+        url?: string;
+        linkFoto?: string;
+      };
+
+      const localUrl = data.url ?? data.linkFoto;
+      if (!localUrl) {
+        throw error;
+      }
+
+      return {
+        fileId: "",
+        key: `perfil:${entityId ?? "me"}`,
+        url: localUrl,
+        size: file.size,
+        mimeType: file.type,
+      };
+    }
+
+    throw error;
+  }
 }


### PR DESCRIPTION
## Visão geral

Este PR ajusta a UI das páginas de **feed** e **gestão de entidades** e corrige dois bugs (atualização de email e update/remoção de membros).

## Mudanças

### Página de Feed (`/conecta/feed`)
- Removido o título "Entidades" e os cards de perfis (`ProjetoCard`).
- Agora exibe **publicações** (`PostagemCardFeed`) via `GET /postagem`, enriquecidas com nome/logo da entidade (`GET /entidade`).
- Os **filtros (Campus/Departamento/Tipos)** agora filtram as publicações pela entidade de origem.
- Barra superior reformulada: filtros compactos à **esquerda** + **buscar entidades** à **direita** (movida da página de gestão, com debounce e botão Seguir).
- Clicar numa publicação abre o `PostagemModal` em modo visualização.

### Página de Gestão (`/conecta/entidades/gestao`)
- Removida a busca de entidades (movida para o feed).
- Adicionada **busca de processos seletivos abertos por entidade**: digita o nome da entidade → retorna apenas as que têm processos abertos (`classificacao === 'ABERTA'` e `fimInscricao >= agora`).
- Clicar num processo abre o `ProcessoSeletivoViewModal` (já existente).

### Bug fixes
- **Email do perfil não atualizava:** o payload de `handleSave` não enviava `email`. Adicionado ao `PATCH /perfil`.
- **Cargo de membro não salvava (UPDATE/remoção):** `findOne` da entidade não expunha `idPerfil`, fazendo a URL do PATCH/DELETE virar `.../membros/undefined`. Adicionado `idPerfil: true` ao select de membros.

## Detalhes técnicos
- Sem mudanças de contrato de backend além de expor `idPerfil` (aditivo) em `GET /entidade/:id`.
- Backend, sidebar e demais páginas permanecem intactos.

## Verificação
- `pnpm --filter front lint` ✅
- `pnpm --filter front exec tsc --noEmit` ✅
- `eslint` nos arquivos alterados do back ✅